### PR TITLE
Turn some panics into errors

### DIFF
--- a/group/all.go
+++ b/group/all.go
@@ -30,6 +30,8 @@ func init() {
 	register(edwards25519.NewAES128SHA256Ed25519())
 }
 
+// ErrUnknownSuite indicates that the suite was not one of the
+// registered suites.
 var ErrUnknownSuite = errors.New("unknown suite")
 
 // Suite return

--- a/group/all.go
+++ b/group/all.go
@@ -13,23 +13,29 @@
 package group
 
 import (
+	"errors"
 	"strings"
 
+	"github.com/dedis/kyber"
 	"github.com/dedis/kyber/group/edwards25519"
 )
 
-var suites = map[string]interface{}{}
+var suites = map[string]kyber.Group{}
 
-func init() {
-	ed25519 := edwards25519.NewAES128SHA256Ed25519()
-	suites[strings.ToLower(ed25519.String())] = ed25519
+func register(g kyber.Group) {
+	suites[strings.ToLower(g.String())] = g
 }
 
+func init() {
+	register(edwards25519.NewAES128SHA256Ed25519())
+}
+
+var ErrUnknownSuite = errors.New("unknown suite")
+
 // Suite return
-func Suite(name string) interface{} {
-	s, ok := suites[strings.ToLower(name)]
-	if !ok {
-		panic("group has no suite named " + name)
+func Suite(name string) (kyber.Group, error) {
+	if s, ok := suites[strings.ToLower(name)]; ok {
+		return s, nil
 	}
-	return s
+	return nil, ErrUnknownSuite
 }

--- a/group/all_vartime.go
+++ b/group/all_vartime.go
@@ -8,12 +8,8 @@ import (
 )
 
 func init() {
-	curve25519 := curve25519.NewAES128SHA256Ed25519(false)
-	suites[curve25519.String()] = curve25519
-
-	p256 := nist.NewAES128SHA256P256()
-	suites[p256.String()] = p256
-
-	qr512 := nist.NewAES128SHA256QR512()
-	suites[qr512.String()] = qr512
+	register(curve25519.NewAES128SHA256Ed25519(false))
+	register(curve25519.NewAES128SHA256Ed25519(true))
+	register(nist.NewAES128SHA256P256())
+	register(nist.NewAES128SHA256QR512())
 }

--- a/group/curve25519/curve.go
+++ b/group/curve25519/curve.go
@@ -3,11 +3,10 @@
 package curve25519
 
 import (
+	"crypto/cipher"
 	"errors"
 	"fmt"
 	"math/big"
-	//"encoding/hex"
-	"crypto/cipher"
 
 	"github.com/dedis/kyber"
 	"github.com/dedis/kyber/group/mod"
@@ -49,6 +48,13 @@ type curve struct {
 	null kyber.Point // Identity point for this group
 
 	hide hiding // Uniform point encoding method
+}
+
+func (c *curve) String() string {
+	if c.full {
+		return c.Param.String() + "-full"
+	}
+	return c.Param.String()
 }
 
 func (c *curve) IsPrimeOrder() bool {

--- a/group/curve25519/param.go
+++ b/group/curve25519/param.go
@@ -54,7 +54,7 @@ func Param1174() *Param {
 	var p Param
 	var mi mod.Int
 
-	p.Name = "1174"
+	p.Name = "Curve1174"
 	p.P.SetBit(zero, 251, 1).Sub(&p.P, big.NewInt(9))
 	p.Q.SetString("45330879683285730139092453152713398835", 10)
 	p.Q.Sub(&p.P, &p.Q).Div(&p.Q, big.NewInt(4))
@@ -81,7 +81,7 @@ func Param1174() *Param {
 func Param25519() *Param {
 	var p Param
 	var qs big.Int
-	p.Name = "25519"
+	p.Name = "Curve25519"
 	p.P.SetBit(zero, 255, 1).Sub(&p.P, big.NewInt(19))
 	qs.SetString("27742317777372353535851937790883648493", 10)
 	p.Q.SetBit(zero, 252, 1).Add(&p.Q, &qs)
@@ -103,13 +103,14 @@ func Param25519() *Param {
 // http://eprint.iacr.org/2013/647.pdf
 //
 // and more recently in:
+//
 // "Additional Elliptic Curves for IETF protocols"
 // http://tools.ietf.org/html/draft-ladd-safecurves-02
-//
+// (this I-D is now expired)
 func ParamE382() *Param {
 	var p Param
 	var qs big.Int
-	p.Name = "E382"
+	p.Name = "E-382"
 	p.P.SetBit(zero, 382, 1).Sub(&p.P, big.NewInt(105)) // p = 2^382-105
 	qs.SetString("1030303207694556153926491950732314247062623204330168346855", 10)
 	p.Q.SetBit(zero, 380, 1).Sub(&p.Q, &qs)
@@ -127,7 +128,7 @@ func ParamE382() *Param {
 func Param41417() *Param {
 	var p Param
 	var qs big.Int
-	p.Name = "41417"
+	p.Name = "Curve41417"
 	p.P.SetBit(zero, 414, 1).Sub(&p.P, big.NewInt(17))
 	qs.SetString("33364140863755142520810177694098385178984727200411208589594759", 10)
 	p.Q.SetBit(zero, 411, 1).Sub(&p.Q, &qs)
@@ -150,7 +151,7 @@ func Param41417() *Param {
 func ParamE521() *Param {
 	var p Param
 	var qs big.Int
-	p.Name = "E521"
+	p.Name = "E-521"
 	p.P.SetBit(zero, 521, 1).Sub(&p.P, one)
 	qs.SetString("337554763258501705789107630418782636071904961214051226618635150085779108655765", 10)
 	p.Q.SetBit(zero, 519, 1).Sub(&p.Q, &qs)

--- a/group/mod/int.go
+++ b/group/mod/int.go
@@ -29,7 +29,7 @@ const (
 // Int is a generic implementation of finite field arithmetic
 // on integer finite fields with a given constant modulus,
 // built using Go's built-in big.Int package.
-// Int satisfies the kyber.kyber.Scalar interface,
+// Int satisfies the kyber.Scalar interface,
 // and hence serves as a basic implementation of kyber.Scalar,
 // e.g., representing discrete-log exponents of Schnorr groups
 // or scalar multipliers for elliptic curves.

--- a/proof/context.go
+++ b/proof/context.go
@@ -36,7 +36,7 @@ type Verifier func(ctx VerifierContext) error
 type ProverContext interface {
 	Put(message interface{}) error        // Send message to verifier
 	PubRand(message ...interface{}) error // Get public randomness
-	PriRand(message ...interface{})       // Get private randomness
+	PriRand(message ...interface{}) error // Get private randomness
 }
 
 // VerifierContext represents the kyber.environment

--- a/proof/deniable.go
+++ b/proof/deniable.go
@@ -3,6 +3,7 @@ package proof
 import (
 	"bytes"
 	"errors"
+	"fmt"
 
 	"github.com/dedis/kyber"
 )
@@ -51,7 +52,7 @@ func (dp *deniableProver) run(suite Suite, self int, prv Prover,
 
 	nnodes := len(vrf)
 	if self < 0 || self >= nnodes {
-		panic("out-of-range self node")
+		return []error{errors.New("out-of-range self node")}
 	}
 
 	// Initialize error slice entries to a default error indicator,
@@ -225,10 +226,11 @@ func (dp *deniableProver) PubRand(data ...interface{}) error {
 }
 
 // Get private randomness
-func (dp *deniableProver) PriRand(data ...interface{}) {
+func (dp *deniableProver) PriRand(data ...interface{}) error {
 	if err := dp.suite.Read(dp.prirand, data...); err != nil {
-		panic("error reading random stream: " + err.Error())
+		return fmt.Errorf("error reading random stream: %v", err.Error())
 	}
+	return nil
 }
 
 // Interactive Sigma-protocol verifier context.


### PR DESCRIPTION
Avoid panicing inside the library when the reason is external to the
library, or due to bad user input. These should return errors and the
caller may choose to handle them differently than a panic.

Also: rationalize the suite names recognized by group.Suite.

Also: register both Curve25519 and Curve25519-full.

Closes #239.