### PR TITLE
Fix scalar encoding

### DIFF
--- a/group/edwards25519/scalar.go
+++ b/group/edwards25519/scalar.go
@@ -6,6 +6,7 @@ package edwards25519
 
 import (
 	"crypto/cipher"
+	"encoding/hex"
 	"errors"
 	"io"
 	"math/big"
@@ -136,11 +137,12 @@ func (s *scalar) Pick(rand cipher.Stream) kyber.Scalar {
 	return s.setInt(i)
 }
 
+// SetBytes s to b, interpreted as a little endian integer.
 func (s *scalar) SetBytes(b []byte) kyber.Scalar {
 	return s.setInt(mod.NewIntBytes(b, primeOrder, mod.LittleEndian))
 }
 
-// Bytes returns a big-Endian representation of the scalar
+// Bytes returns a big-endian representation of the scalar
 func (s *scalar) Bytes() []byte {
 	var buf = s.v
 	bytes.Reverse(buf[:], buf[:])
@@ -153,9 +155,13 @@ func (s *scalar) Bytes() []byte {
 	return buf[i:]
 }
 
-// String returns the string representation of this scalar.
+// String returns the string representation of this scalar (fixed length of 32 bytes, little endian).
 func (s *scalar) String() string {
-	return s.toInt().String()
+	b, _ := s.toInt().MarshalBinary()
+	for len(b) < 32 {
+		b = append(b, 0)
+	}
+	return hex.EncodeToString(b)
 }
 
 // Encoded length of this object in bytes.

--- a/group/edwards25519/scalar_test.go
+++ b/group/edwards25519/scalar_test.go
@@ -98,6 +98,16 @@ func TestSimpleCTScalar(t *testing.T) {
 	testSimple(t, newSimpleCTScalar)
 }
 
+func TestString(t *testing.T) {
+	// Create a scalar that would trigger #262.
+	s := new(scalar)
+	s.SetInt64(0x100)
+	s.Add(s, one)
+	if s.String() != "0101000000000000000000000000000000000000000000000000000000000000" {
+		t.Fatal("unexepcted result from String():", s.String())
+	}
+}
+
 func testSimple(t *testing.T, new func() kyber.Scalar) {
 	s1 := new()
 	s2 := new()

--- a/group/mod/int.go
+++ b/group/mod/int.go
@@ -44,11 +44,10 @@ const (
 // target objects, and receive the modulus of the first operand.
 // For efficiency the modulus field M is a pointer,
 // whose target is assumed never to change.
-//
 type Int struct {
 	V  big.Int   // Integer value from 0 through M-1
 	M  *big.Int  // Modulus for finite field arithmetic
-	BO ByteOrder // Endianness considered for this int
+	BO ByteOrder // Endianness which will be used on input and output
 }
 
 // NewInt creaters a new Int with a given big.Int and a big.Int modulus.
@@ -109,7 +108,7 @@ func (i *Int) InitString(n, d string, base int, m *big.Int) *Int {
 	return i
 }
 
-// Return the Int's integer value in decimal string representation.
+// Return the Int's integer value in hexadecimal string representation.
 func (i *Int) String() string {
 	return hex.EncodeToString(i.V.Bytes())
 }

--- a/util/encoding/encoding.go
+++ b/util/encoding/encoding.go
@@ -144,14 +144,14 @@ func write64(wc io.WriteCloser, data ...kyber.Marshaling) error {
 	return wc.Close()
 }
 
-func getHex(r io.Reader, len int) ([]byte, error) {
-	bufHex := make([]byte, len*2)
-	bufByte := make([]byte, len)
-	l, err := r.Read(bufHex)
+func getHex(r io.Reader, l int) ([]byte, error) {
+	bufHex := make([]byte, l*2)
+	bufByte := make([]byte, l)
+	n, err := r.Read(bufHex)
 	if err != nil {
 		return nil, err
 	}
-	if l < len {
+	if n < len(bufHex) {
 		return nil, errors.New("didn't get enough bytes from stream")
 	}
 	_, err = hex.Decode(bufByte, bufHex)


### PR DESCRIPTION
Because scalar encoding depended on converting to a mod.Int
first, the most significant bytes could be lost.

Also fix problems in the place that decodes it, which was hiding
the real error.