### PR TITLE
Fix endianness of SetBytes

### DIFF
--- a/group/edwards25519/scalar.go
+++ b/group/edwards25519/scalar.go
@@ -136,9 +136,9 @@ func (s *scalar) Pick(rand cipher.Stream) kyber.Scalar {
 	return s.setInt(i)
 }
 
-// SetBytes s to b, interpreted as a little endian integer.
+// SetBytes s to b, interpreted as a big endian integer.
 func (s *scalar) SetBytes(b []byte) kyber.Scalar {
-	return s.setInt(mod.NewIntBytes(b, primeOrder, mod.LittleEndian))
+	return s.setInt(mod.NewIntBytes(b, primeOrder, mod.BigEndian))
 }
 
 // Bytes returns a big-endian representation of the scalar


### PR DESCRIPTION
The Scalar documentation says that SetBytes uses big-endian integers, and scalar.Bytes() in fact does use big-endian. Fix SetBytes to use it too.