### PR TITLE
Some simplifications

### DIFF
--- a/group/edwards25519/fe.go
+++ b/group/edwards25519/fe.go
@@ -62,16 +62,14 @@ func feCMove(f, g *fieldElement, b int32) {
 }
 
 func load3(in []byte) int64 {
-	var r int64
-	r = int64(in[0])
+	r := int64(in[0])
 	r |= int64(in[1]) << 8
 	r |= int64(in[2]) << 16
 	return r
 }
 
 func load4(in []byte) int64 {
-	var r int64
-	r = int64(in[0])
+	r := int64(in[0])
 	r |= int64(in[1]) << 8
 	r |= int64(in[2]) << 16
 	r |= int64(in[3]) << 24

--- a/group/edwards25519/ge.go
+++ b/group/edwards25519/ge.go
@@ -291,8 +291,7 @@ func slide(r *[256]int8, a *[32]byte) {
 
 	// Explode the exponent a into a little-endian array, one bit per byte
 	for i := range a {
-		var ai int8
-		ai = int8(a[i])
+		ai := int8(a[i])
 		for j := 0; j < 8; j++ {
 			r[i*8+j] = ai & 1
 			ai >>= 1

--- a/group/mod/int_test.go
+++ b/group/mod/int_test.go
@@ -84,7 +84,7 @@ func TestIntClone(t *testing.T) {
 	clone.Add(clone, clone)
 	b1, _ := clone.MarshalBinary()
 	b2, _ := base.MarshalBinary()
-	if bytes.Compare(b1, b2) == 0 {
+	if bytes.Equal(b1, b2) {
 		t.Error("Should not be equal")
 	}
 }

--- a/share/dkg/pedersen/dkg.go
+++ b/share/dkg/pedersen/dkg.go
@@ -326,10 +326,7 @@ func (d *DistKeyGenerator) DistKeyShare() (*DistKeyShare, error) {
 			return true
 		}
 		pub, err = pub.Add(poly)
-		if err != nil {
-			return false
-		}
-		return true
+		return err == nil
 	})
 
 	if err != nil {

--- a/share/dkg/rabin/dkg.go
+++ b/share/dkg/rabin/dkg.go
@@ -637,10 +637,7 @@ func (d *DistKeyGenerator) DistKeyShare() (*DistKeyShare, error) {
 			return true
 		}
 		pub, err = pub.Add(poly)
-		if err != nil {
-			return false
-		}
-		return true
+		return err == nil
 	})
 
 	if err != nil {

--- a/xof/blake/blake.go
+++ b/xof/blake/blake.go
@@ -59,7 +59,6 @@ func (x *xof) Reseed() {
 	y := New(x.key)
 	// Steal the XOF implementation, and put it inside of x.
 	x.impl = y.(*xof).impl
-	return
 }
 
 func (x *xof) XORKeyStream(dst, src []byte) {

--- a/xof/keccak/keccak.go
+++ b/xof/keccak/keccak.go
@@ -34,7 +34,6 @@ func (x *xof) Reseed() {
 	x.Read(x.key)
 	x.sh = sha3.NewShake256()
 	x.sh.Write(x.key)
-	return
 }
 
 func (x *xof) Read(dst []byte) (int, error) {


### PR DESCRIPTION
 * no unnecessary return
 * shorter bool check
 * merge variable declaration and assignment
 * shorter version of some functions i.e bytes.Equal instead of compare