### PR TITLE
Remove tag experimental from proof and neff

### DIFF
--- a/doc.go
+++ b/doc.go
@@ -69,7 +69,6 @@ of a wide variety of statements such as,
 or I know the secret y associated with public key Y",
 without revealing anything about either secret
 or even which branch of the "or" clause is true.
-(Requires build tag "experimental".)
 
 - sign: The sign directory contains different signature schemes.
 
@@ -90,7 +89,7 @@ unique, compact and efficiently verifiable signature using the Schnorr signature
 which can be used to implement (for example) voting or auction schemes
 that keep the sources of individual votes or bids private
 without anyone having to trust more than one of the shuffler(s) to shuffle
-votes/bids honestly. (Requires build tag "experimental".)
+votes/bids honestly.
 
 Disclaimer
 

--- a/proof/clique.go
+++ b/proof/clique.go
@@ -1,5 +1,3 @@
-// +build experimental
-
 package proof
 
 // A clique protocol is a kyber.on for a cryptographic protocol

--- a/proof/context.go
+++ b/proof/context.go
@@ -1,5 +1,3 @@
-// +build experimental
-
 package proof
 
 // Prover represents the prover role in an arbitrary Sigma-protocol.

--- a/proof/deniable.go
+++ b/proof/deniable.go
@@ -1,5 +1,3 @@
-// +build experimental
-
 package proof
 
 import (

--- a/proof/deniable_test.go
+++ b/proof/deniable_test.go
@@ -1,5 +1,3 @@
-// +build experimental
-
 package proof
 
 import (

--- a/proof/hash_test.go
+++ b/proof/hash_test.go
@@ -1,5 +1,3 @@
-// +build experimental
-
 package proof
 
 import (

--- a/proof/proof.go
+++ b/proof/proof.go
@@ -1,12 +1,8 @@
-// +build experimental
-
 // Package proof implements generic support for Sigma-protocols
 // and discrete logarithm proofs in the Camenisch/Stadler framework.
 // For the cryptographic foundations of this framework see
 // "Proof Systems for General Statements about Discrete Logarithms" at
 // ftp://ftp.inf.ethz.ch/pub/crypto/publications/CamSta97b.pdf.
-//
-// Package shuffle requires build tag "experimental".
 package proof
 
 import (

--- a/proof/proof_test.go
+++ b/proof/proof_test.go
@@ -1,5 +1,3 @@
-// +build experimental
-
 package proof
 
 import (

--- a/shuffle/biffle.go
+++ b/shuffle/biffle.go
@@ -1,5 +1,3 @@
-// +build experimental
-
 package shuffle
 
 import (

--- a/shuffle/biffle_test.go
+++ b/shuffle/biffle_test.go
@@ -1,5 +1,3 @@
-// +build experimental
-
 package shuffle
 
 import (

--- a/shuffle/pair.go
+++ b/shuffle/pair.go
@@ -1,5 +1,3 @@
-// +build experimental
-
 // Package shuffle implements Andrew Neff's verifiable shuffle proof scheme.
 // Neff's shuffle proof algorithm as implemented here is described in the paper
 // "Verifiable Mixing (Shuffling) of ElGamal Pairs", April 2004.
@@ -19,8 +17,6 @@
 // The general PairShuffle builds on this SimpleShuffle scheme,
 // but SimpleShuffle may also be used by itself in situations
 // that satisfy its assumptions, and is more efficient.
-//
-// Package shuffle requires build tag "experimental".
 package shuffle
 
 import (

--- a/shuffle/shuffle_test.go
+++ b/shuffle/shuffle_test.go
@@ -1,5 +1,3 @@
-// +build experimental
-
 package shuffle
 
 import (

--- a/shuffle/simple.go
+++ b/shuffle/simple.go
@@ -1,5 +1,3 @@
-// +build experimental
-
 package shuffle
 
 import (

--- a/shuffle/vartime_test.go
+++ b/shuffle/vartime_test.go
@@ -1,4 +1,4 @@
-// +build experimental,vartime
+// +build vartime
 
 package shuffle
 


### PR DESCRIPTION
We are about to use these for e-voting, which is much closer
to "production" than "experimental".

Also: Fix a build problem that was hidden by tag experimental.