### PR TITLE
Fix Scalar (Un)marshaling

### DIFF
--- a/pairing/bn256/scalar.go
+++ b/pairing/bn256/scalar.go
@@ -3,6 +3,7 @@ package bn256
 import (
 	"crypto/cipher"
 	"crypto/subtle"
+	"errors"
 	"io"
 	"math/big"
 
@@ -20,8 +21,15 @@ func newScalar() kyber.Scalar {
 }
 
 func (s *scalar) Equal(a kyber.Scalar) bool {
-	x := a.(*scalar).x
-	return subtle.ConstantTimeCompare(s.x.Bytes(), x.Bytes()) == 1
+	sm, err := s.MarshalBinary()
+	if err != nil {
+		return false
+	}
+	am, err := a.MarshalBinary()
+	if err != nil {
+		return false
+	}
+	return subtle.ConstantTimeCompare(sm, am) == 1
 }
 
 func (s *scalar) Set(a kyber.Scalar) kyber.Scalar {
@@ -107,7 +115,8 @@ func (s *scalar) SetBytes(buf []byte) kyber.Scalar {
 }
 
 func (s *scalar) Bytes() []byte {
-	return s.x.Bytes()
+	sm, _ := s.MarshalBinary()
+	return sm
 }
 
 func (s *scalar) SetVarTime(varTime bool) error {
@@ -116,8 +125,14 @@ func (s *scalar) SetVarTime(varTime bool) error {
 
 func (s *scalar) MarshalBinary() ([]byte, error) {
 	n := s.MarshalSize()
-	buf := s.x.Bytes()
-	return buf[:n], nil
+	buf := make([]byte, n)
+	bytes := s.x.Bytes()
+	if n < len(bytes) {
+		return nil, errors.New("bn256.Scalar: unexpected size")
+	}
+	m := n - len(bytes)
+	copy(buf[m:n], bytes)
+	return buf, nil
 }
 
 func (s *scalar) MarshalTo(w io.Writer) (int, error) {

--- a/pairing/bn256/scalar.go
+++ b/pairing/bn256/scalar.go
@@ -21,14 +21,8 @@ func newScalar() kyber.Scalar {
 }
 
 func (s *scalar) Equal(a kyber.Scalar) bool {
-	sm, err := s.MarshalBinary()
-	if err != nil {
-		return false
-	}
-	am, err := a.MarshalBinary()
-	if err != nil {
-		return false
-	}
+	sm, _ := s.MarshalBinary()
+	am, _ := a.MarshalBinary()
 	return subtle.ConstantTimeCompare(sm, am) == 1
 }
 

--- a/pairing/bn256/suite_test.go
+++ b/pairing/bn256/suite_test.go
@@ -8,6 +8,22 @@ import (
 	"golang.org/x/crypto/bn256"
 )
 
+func TestScalarMarshal(t *testing.T) {
+	suite := NewSuiteBN256()
+	a := suite.G1().Scalar().Pick(random.New())
+	b := suite.G1().Scalar()
+	am, err := a.MarshalBinary()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := b.UnmarshalBinary(am); err != nil {
+		t.Fatal(err)
+	}
+	if !a.Equal(b) {
+		t.Fatal("bn256: scalars not equal")
+	}
+}
+
 func TestG1(t *testing.T) {
 	suite := NewSuiteBN256()
 	k := suite.G1().Scalar().Pick(random.New())

--- a/pairing/bn256/suite_test.go
+++ b/pairing/bn256/suite_test.go
@@ -24,6 +24,30 @@ func TestScalarMarshal(t *testing.T) {
 	}
 }
 
+func TestScalarOps(t *testing.T) {
+	suite := NewSuiteBN256()
+	a := suite.G1().Scalar().Pick(random.New())
+	b := suite.G1().Scalar()
+	b.Add(a, b)
+	a.Sub(a, b)
+	if !a.Equal(suite.G1().Scalar().Zero()) {
+		t.Fatal("bn256: add sub failed")
+	}
+	a.Pick(random.New())
+	b.Set(suite.G1().Scalar().One())
+	b.Mul(a, b)
+	a.Div(a, b)
+	if !a.Equal(suite.G1().Scalar().One()) {
+		t.Fatal("bn256: mul div failed")
+	}
+	a.Pick(random.New())
+	b.Inv(a)
+	a.Mul(a, b)
+	if !a.Equal(suite.G1().Scalar().One()) {
+		t.Fatal("bn256: inversion failed")
+	}
+}
+
 func TestG1(t *testing.T) {
 	suite := NewSuiteBN256()
 	k := suite.G1().Scalar().Pick(random.New())


### PR DESCRIPTION
This PR fixes the bug found by @froelich triggered by scalars being marshaled into variable-sized slices. Now scalars are marshaled to zero-padded 32-byte slices.