### PR TITLE
Polyfix again

### DIFF
--- a/share/poly.go
+++ b/share/poly.go
@@ -46,7 +46,7 @@ type PriPoly struct {
 // NewPriPoly creates a new secret sharing polynomial using the provided
 // cryptographic group, the secret sharing threshold t, and the secret to be
 // shared s. If s is nil, a new s is chosen using the provided randomness
-// stream.
+// stream rand.
 func NewPriPoly(group kyber.Group, t int, s kyber.Scalar, rand cipher.Stream) *PriPoly {
 	coeffs := make([]kyber.Scalar, t)
 	coeffs[0] = s
@@ -135,11 +135,11 @@ func (p *PriPoly) Commit(b kyber.Point) *PubPoly {
 	return &PubPoly{p.g, b, commits}
 }
 
-// Mul multiples p  and q together. The result is a polynomial of the sum of
+// Mul multiples p and q together. The result is a polynomial of the sum of
 // the two degrees of p and q. NOTE: it does not check for null coefficients
 // after the multiplication, so the degree of the polynomial is "always" as
 // described above. This is only for use in secret sharing schemes. It is not
-// a general polynomial manipulation routine.
+// a general polynomial multiplication routine.
 func (p *PriPoly) Mul(q *PriPoly) *PriPoly {
 	d1 := len(p.coeffs) - 1
 	d2 := len(q.coeffs) - 1
@@ -210,9 +210,10 @@ func xMinusConst(g kyber.Group, c kyber.Scalar) *PriPoly {
 }
 
 // RecoverPriPoly takes a list of shares and the parameters t and n to
-// reconstruct the secret polynomial completely, i.e., all private coefficients.
-// It is up to the caller to make sure there are enough shares to correctly
-// re-construct the polynomial. There must be at least t shares.
+// reconstruct the secret polynomial completely, i.e., all private
+// coefficients.  It is up to the caller to make sure that there are enough
+// shares to correctly re-construct the polynomial. There must be at least t
+// shares.
 func RecoverPriPoly(g kyber.Group, shares []*PriShare, t, n int) (*PriPoly, error) {
 	x := xScalar(g, shares, t, n)
 	if len(x) != t {
@@ -222,7 +223,7 @@ func RecoverPriPoly(g kyber.Group, shares []*PriShare, t, n int) (*PriPoly, erro
 	var accPoly *PriPoly
 	var err error
 	den := g.Scalar()
-	// notations following the wikipedia article on Lagrange interpolation
+	// Notations follow the Wikipedia article on Lagrange interpolation
 	// https://en.wikipedia.org/wiki/Lagrange_polynomial
 	for j, xj := range x {
 		var basis = &PriPoly{

--- a/share/poly_test.go
+++ b/share/poly_test.go
@@ -11,7 +11,7 @@ func TestSecretRecovery(test *testing.T) {
 	g := edwards25519.NewBlakeSHA256Ed25519()
 	n := 10
 	t := n/2 + 1
-	poly := NewPriPoly(g, t, nil)
+	poly := NewPriPoly(g, t, nil, g.RandomStream())
 	shares := poly.Shares(n)
 
 	recovered, err := RecoverSecret(g, shares, t, n)
@@ -28,7 +28,7 @@ func TestSecretRecoveryDelete(test *testing.T) {
 	g := edwards25519.NewBlakeSHA256Ed25519()
 	n := 10
 	t := n/2 + 1
-	poly := NewPriPoly(g, t, nil)
+	poly := NewPriPoly(g, t, nil, g.RandomStream())
 	shares := poly.Shares(n)
 
 	// Corrupt a few shares
@@ -52,7 +52,7 @@ func TestSecretRecoveryDeleteFail(test *testing.T) {
 	n := 10
 	t := n/2 + 1
 
-	poly := NewPriPoly(g, t, nil)
+	poly := NewPriPoly(g, t, nil, g.RandomStream())
 	shares := poly.Shares(n)
 
 	// Corrupt one more share than acceptable
@@ -73,9 +73,9 @@ func TestSecretPolyEqual(test *testing.T) {
 	n := 10
 	t := n/2 + 1
 
-	p1 := NewPriPoly(g, t, nil)
-	p2 := NewPriPoly(g, t, nil)
-	p3 := NewPriPoly(g, t, nil)
+	p1 := NewPriPoly(g, t, nil, g.RandomStream())
+	p2 := NewPriPoly(g, t, nil, g.RandomStream())
+	p3 := NewPriPoly(g, t, nil, g.RandomStream())
 
 	p12, _ := p1.Add(p2)
 	p13, _ := p1.Add(p3)
@@ -93,7 +93,7 @@ func TestPublicCheck(test *testing.T) {
 	n := 10
 	t := n/2 + 1
 
-	priPoly := NewPriPoly(g, t, nil)
+	priPoly := NewPriPoly(g, t, nil, g.RandomStream())
 	priShares := priPoly.Shares(n)
 	pubPoly := priPoly.Commit(nil)
 
@@ -109,7 +109,7 @@ func TestPublicRecovery(test *testing.T) {
 	n := 10
 	t := n/2 + 1
 
-	priPoly := NewPriPoly(g, t, nil)
+	priPoly := NewPriPoly(g, t, nil, g.RandomStream())
 	pubPoly := priPoly.Commit(nil)
 	pubShares := pubPoly.Shares(n)
 
@@ -128,7 +128,7 @@ func TestPublicRecoveryDelete(test *testing.T) {
 	n := 10
 	t := n/2 + 1
 
-	priPoly := NewPriPoly(g, t, nil)
+	priPoly := NewPriPoly(g, t, nil, g.RandomStream())
 	pubPoly := priPoly.Commit(nil)
 	shares := pubPoly.Shares(n)
 
@@ -153,7 +153,7 @@ func TestPublicRecoveryDeleteFail(test *testing.T) {
 	n := 10
 	t := n/2 + 1
 
-	priPoly := NewPriPoly(g, t, nil)
+	priPoly := NewPriPoly(g, t, nil, g.RandomStream())
 	pubPoly := priPoly.Commit(nil)
 	shares := pubPoly.Shares(n)
 
@@ -175,8 +175,8 @@ func TestPrivateAdd(test *testing.T) {
 	n := 10
 	t := n/2 + 1
 
-	p := NewPriPoly(g, t, nil)
-	q := NewPriPoly(g, t, nil)
+	p := NewPriPoly(g, t, nil, g.RandomStream())
+	q := NewPriPoly(g, t, nil, g.RandomStream())
 
 	r, err := p.Add(q)
 	if err != nil {
@@ -200,8 +200,8 @@ func TestPublicAdd(test *testing.T) {
 	G := g.Point().Pick(g.RandomStream())
 	H := g.Point().Pick(g.RandomStream())
 
-	p := NewPriPoly(g, t, nil)
-	q := NewPriPoly(g, t, nil)
+	p := NewPriPoly(g, t, nil, g.RandomStream())
+	q := NewPriPoly(g, t, nil, g.RandomStream())
 
 	P := p.Commit(G)
 	Q := q.Commit(H)
@@ -233,9 +233,9 @@ func TestPublicPolyEqual(test *testing.T) {
 
 	G := g.Point().Pick(g.RandomStream())
 
-	p1 := NewPriPoly(g, t, nil)
-	p2 := NewPriPoly(g, t, nil)
-	p3 := NewPriPoly(g, t, nil)
+	p1 := NewPriPoly(g, t, nil, g.RandomStream())
+	p2 := NewPriPoly(g, t, nil, g.RandomStream())
+	p3 := NewPriPoly(g, t, nil, g.RandomStream())
 
 	P1 := p1.Commit(G)
 	P2 := p2.Commit(G)
@@ -256,8 +256,8 @@ func TestPriPolyMul(test *testing.T) {
 	suite := edwards25519.NewBlakeSHA256Ed25519()
 	n := 10
 	t := n/2 + 1
-	a := NewPriPoly(suite, t, nil)
-	b := NewPriPoly(suite, t, nil)
+	a := NewPriPoly(suite, t, nil, suite.RandomStream())
+	b := NewPriPoly(suite, t, nil, suite.RandomStream())
 
 	c := a.Mul(b)
 	assert.Equal(test, len(a.coeffs)+len(b.coeffs)-1, len(c.coeffs))
@@ -283,7 +283,7 @@ func TestRecoverPriPoly(test *testing.T) {
 	suite := edwards25519.NewBlakeSHA256Ed25519()
 	n := 10
 	t := n/2 + 1
-	a := NewPriPoly(suite, t, nil)
+	a := NewPriPoly(suite, t, nil, suite.RandomStream())
 
 	shares := a.Shares(n)
 	reverses := make([]*PriShare, len(shares))

--- a/share/pvss/pvss.go
+++ b/share/pvss/pvss.go
@@ -51,7 +51,7 @@ func EncShares(suite Suite, H kyber.Point, X []kyber.Point, secret kyber.Scalar,
 	encShares := make([]*PubVerShare, n)
 
 	// Create secret sharing polynomial
-	priPoly := share.NewPriPoly(suite, t, secret)
+	priPoly := share.NewPriPoly(suite, t, secret, suite.RandomStream())
 
 	// Create secret set of shares
 	priShares := priPoly.Shares(n)

--- a/share/vss/pedersen/vss.go
+++ b/share/vss/pedersen/vss.go
@@ -128,7 +128,7 @@ func NewDealer(suite Suite, longterm, secret kyber.Scalar, verifiers []kyber.Poi
 	}
 	d.t = t
 
-	f := share.NewPriPoly(d.suite, d.t, d.secret)
+	f := share.NewPriPoly(d.suite, d.t, d.secret, suite.RandomStream())
 	d.pub = d.suite.Point().Mul(d.long, nil)
 
 	// Compute public polynomial coefficients

--- a/share/vss/rabin/vss.go
+++ b/share/vss/rabin/vss.go
@@ -146,8 +146,8 @@ func NewDealer(suite Suite, longterm, secret kyber.Scalar, verifiers []kyber.Poi
 	d.t = t
 
 	H := deriveH(d.suite, d.verifiers)
-	f := share.NewPriPoly(d.suite, d.t, d.secret)
-	g := share.NewPriPoly(d.suite, d.t, nil)
+	f := share.NewPriPoly(d.suite, d.t, d.secret, suite.RandomStream())
+	g := share.NewPriPoly(d.suite, d.t, nil, suite.RandomStream())
 	d.pub = d.suite.Point().Mul(d.long, nil)
 
 	// Compute public polynomial coefficients

--- a/sign/bls/bls.go
+++ b/sign/bls/bls.go
@@ -1,6 +1,6 @@
 // Package bls implements the Boneh-Lynn-Shacham (BLS) signature scheme which
-// requires pairing-based cryptography. For more details on BLS see the paper
-// "Short Signatures from the Weil Pairing".
+// was introduced in the paper "Short Signatures from the Weil Pairing". BLS
+// requires pairing-based cryptography.
 package bls
 
 import (
@@ -19,8 +19,8 @@ func NewKeyPair(suite pairing.Suite, random cipher.Stream) (kyber.Scalar, kyber.
 	return x, X
 }
 
-// Sign creates a BLS signature s = x * H(m) on a message m using the private
-// key x. The signature s is a point on curve G1.
+// Sign creates a BLS signature S = x * H(m) on a message m using the private
+// key x. The signature S is a point on curve G1.
 func Sign(suite pairing.Suite, x kyber.Scalar, msg []byte) ([]byte, error) {
 	HM := hashToPoint(suite, msg)
 	xHM := HM.Mul(x, HM)
@@ -31,9 +31,9 @@ func Sign(suite pairing.Suite, x kyber.Scalar, msg []byte) ([]byte, error) {
 	return s, nil
 }
 
-// Verify checks the given BLS signature s on the message m using the public
+// Verify checks the given BLS signature S on the message m using the public
 // key X by verifying that the equality e(H(m), X) == e(H(m), x*B2) ==
-// e(x*H(m), B2) == e(s, B2) holds where e is the pairing operation and B2 is
+// e(x*H(m), B2) == e(S, B2) holds where e is the pairing operation and B2 is
 // the base point from curve G2.
 func Verify(suite pairing.Suite, X kyber.Point, msg, sig []byte) error {
 	HM := hashToPoint(suite, msg)

--- a/sign/bls/bls.go
+++ b/sign/bls/bls.go
@@ -1,3 +1,6 @@
+// Package bls implements the Boneh-Lynn-Shacham (BLS) signature scheme which
+// requires pairing-based cryptography. For more details on BLS see the paper
+// "Short Signatures from the Weil Pairing".
 package bls
 
 import (

--- a/sign/tbls/tbls.go
+++ b/sign/tbls/tbls.go
@@ -2,11 +2,12 @@
 // scheme. During setup a group of n participants runs a distributed key
 // generation algorithm (see kyber/share/dkg) to compute a joint public signing
 // key X and one secret key share xi for each of the n signers. To compute a
-// signature on a message m, at least t ouf of n signers have to provide
-// partial (BLS) signatures si on m using their individual key shares xi which
-// can then be used to recover the full (regular) BLS signature s via Lagrange
-// interpolation. The signature s can be verified with the initially
-// established group key X.
+// signature S on a message m, at least t ouf of n signers have to provide
+// partial (BLS) signatures Si on m using their individual key shares xi which
+// can then be used to recover the full (regular) BLS signature S via Lagrange
+// interpolation. The signature S can be verified with the initially
+// established group key X. Signatures are points on curve G1 and public keys
+// are points on curve G2.
 package tbls
 
 import (
@@ -18,12 +19,12 @@ import (
 	"github.com/dedis/kyber/sign/bls"
 )
 
-// SigShare encodes a threshold BLS signature share s = i || v where the 2-byte
+// SigShare encodes a threshold BLS signature share Si = i || v where the 2-byte
 // big-endian value i corresponds to the share's index and v represents the
-// share's value.
+// share's value. The signature share Si is a point on curve G1.
 type SigShare []byte
 
-// Index returns the index i of the TBLS share.
+// Index returns the index i of the TBLS share Si.
 func (s *SigShare) Index() (int, error) {
 	var index uint16
 	buf := bytes.NewReader(*s)
@@ -34,12 +35,12 @@ func (s *SigShare) Index() (int, error) {
 	return int(index), nil
 }
 
-// Value returns the value v of the TBLS share.
+// Value returns the value v of the TBLS share Si.
 func (s *SigShare) Value() []byte {
 	return []byte(*s)[2:]
 }
 
-// Sign creates a threshold BLS signature si = xi * H(m) on the given message m
+// Sign creates a threshold BLS signature Si = xi * H(m) on the given message m
 // using the provided secret key share xi.
 func Sign(suite pairing.Suite, private *share.PriShare, msg []byte) ([]byte, error) {
 	buf := new(bytes.Buffer)
@@ -56,7 +57,7 @@ func Sign(suite pairing.Suite, private *share.PriShare, msg []byte) ([]byte, err
 	return buf.Bytes(), nil
 }
 
-// Verify checks the given threshold BLS signature si on the message m using
+// Verify checks the given threshold BLS signature Si on the message m using
 // the public key share Xi that is associated to the secret key share xi. This
 // public key share Xi can be computed by evaluating the public sharing
 // polynonmial at the share's index i.
@@ -69,8 +70,8 @@ func Verify(suite pairing.Suite, public *share.PubPoly, msg, sig []byte) error {
 	return bls.Verify(suite, public.Eval(i).V, msg, s.Value())
 }
 
-// Recover reconstructs the full BLS signature s = x * H(m) from a threshold t
-// of signature shares si using Lagrange interpolation. The full signature s
+// Recover reconstructs the full BLS signature S = x * H(m) from a threshold t
+// of signature shares Si using Lagrange interpolation. The full signature S
 // can be verified through the regular BLS verification routine using the
 // shared public key X. The shared public key can be computed by evaluating the
 // public sharing polynomial at index 0.

--- a/sign/tbls/tbls.go
+++ b/sign/tbls/tbls.go
@@ -1,3 +1,12 @@
+// Package tbls implements the (t,n)-threshold Boneh-Lynn-Shacham signature
+// scheme. During setup a group of n participants runs a distributed key
+// generation algorithm (see kyber/share/dkg) to compute a joint public signing
+// key X and one secret key share xi for each of the n signers. To compute a
+// signature on a message m, at least t ouf of n signers have to provide
+// partial (BLS) signatures si on m using their individual key shares xi which
+// can then be used to recover the full (regular) BLS signature s via Lagrange
+// interpolation. The signature s can be verified with the initially
+// established group key X.
 package tbls
 
 import (

--- a/sign/tbls/tbls_test.go
+++ b/sign/tbls/tbls_test.go
@@ -13,12 +13,11 @@ func TestTBLS(test *testing.T) {
 	var err error
 	msg := []byte("Hello threshold Boneh-Lynn-Shacham")
 	suite := bn256.NewSuite()
-	g2s := bn256.NewSingleGroupSuite(suite.G2())
 	n := 10
 	t := n/2 + 1
 	secret := suite.G1().Scalar().Pick(suite.RandomStream())
-	priPoly := share.NewPriPoly(g2s, t, secret, suite.RandomStream())
-	pubPoly := priPoly.Commit(g2s.Point().Base())
+	priPoly := share.NewPriPoly(suite.G2(), t, secret, suite.RandomStream())
+	pubPoly := priPoly.Commit(suite.G2().Point().Base())
 	sigShares := make([][]byte, 0)
 	for _, x := range priPoly.Shares(n) {
 		sig, err := Sign(suite, x, msg)

--- a/sign/tbls/tbls_test.go
+++ b/sign/tbls/tbls_test.go
@@ -6,7 +6,6 @@ import (
 	"github.com/dedis/kyber/pairing/bn256"
 	"github.com/dedis/kyber/share"
 	"github.com/dedis/kyber/sign/bls"
-	"github.com/dedis/kyber/util/random"
 	"github.com/stretchr/testify/require"
 )
 
@@ -17,8 +16,8 @@ func TestTBLS(test *testing.T) {
 	g2s := bn256.NewSingleGroupSuite(suite.G2())
 	n := 10
 	t := n/2 + 1
-	secret := suite.G1().Scalar().Pick(random.New())
-	priPoly := share.NewPriPoly(g2s, t, secret)
+	secret := suite.G1().Scalar().Pick(suite.RandomStream())
+	priPoly := share.NewPriPoly(g2s, t, secret, suite.RandomStream())
 	pubPoly := priPoly.Commit(g2s.Point().Base())
 	sigShares := make([][]byte, 0)
 	for _, x := range priPoly.Shares(n) {


### PR DESCRIPTION
This PR removes the suite interface from the secret sharing code which complicated implementations at other places (e.g., the code for pairings).