### PR TITLE
[VSS] changing dhkey to bytes

### DIFF
--- a/share/vss/pedersen/vss.go
+++ b/share/vss/pedersen/vss.go
@@ -65,7 +65,7 @@ type Deal struct {
 // longterm secret key.
 type EncryptedDeal struct {
 	// Ephemeral Diffie Hellman key
-	DHKey kyber.Point
+	DHKey []byte
 	// Signature of the DH key by the longterm key of the dealer
 	Signature []byte
 	// Nonce used for the encryption
@@ -200,8 +200,9 @@ func (d *Dealer) EncryptedDeal(i int) (*EncryptedDeal, error) {
 		return nil, err
 	}
 	encrypted := gcm.Seal(nil, nonce, dealBuff, d.hkdfContext)
+	dhBytes, _ := dhPublic.MarshalBinary()
 	return &EncryptedDeal{
-		DHKey:     dhPublic,
+		DHKey:     dhBytes,
 		Signature: signature,
 		Nonce:     nonce,
 		Cipher:    encrypted,
@@ -387,17 +388,18 @@ func (v *Verifier) ProcessEncryptedDeal(e *EncryptedDeal) (*Response, error) {
 }
 
 func (v *Verifier) decryptDeal(e *EncryptedDeal) (*Deal, error) {
-	ephBuff, err := e.DHKey.MarshalBinary()
-	if err != nil {
-		return nil, err
-	}
+	ephBuff := e.DHKey
 	// verify signature
 	if err := schnorr.Verify(v.suite, v.dealer, ephBuff, e.Signature); err != nil {
 		return nil, err
 	}
 
 	// compute shared key and AES526-GCM cipher
-	pre := dhExchange(v.suite, v.longterm, e.DHKey)
+	dhKey := v.suite.Point()
+	if err := dhKey.UnmarshalBinary(e.DHKey); err != nil {
+		return nil, err
+	}
+	pre := dhExchange(v.suite, v.longterm, dhKey)
 	gcm, err := newAEAD(v.suite.Hash, pre, v.hkdfContext)
 	if err != nil {
 		return nil, err

--- a/share/vss/pedersen/vss.go
+++ b/share/vss/pedersen/vss.go
@@ -388,9 +388,8 @@ func (v *Verifier) ProcessEncryptedDeal(e *EncryptedDeal) (*Response, error) {
 }
 
 func (v *Verifier) decryptDeal(e *EncryptedDeal) (*Deal, error) {
-	ephBuff := e.DHKey
 	// verify signature
-	if err := schnorr.Verify(v.suite, v.dealer, ephBuff, e.Signature); err != nil {
+	if err := schnorr.Verify(v.suite, v.dealer, e.DHKey, e.Signature); err != nil {
 		return nil, err
 	}
 

--- a/share/vss/pedersen/vss_test.go
+++ b/share/vss/pedersen/vss_test.go
@@ -205,7 +205,8 @@ func TestVSSVerifierDecryptDeal(t *testing.T) {
 
 	// wrong dh key
 	goodDh := encD.DHKey
-	encD.DHKey, _ = suite.Point().Null().MarshalBinary()
+	encD.DHKey, err = suite.Point().Null().MarshalBinary()
+	require.Nil(t, err)
 	decD, err = v.decryptDeal(encD)
 	assert.Error(t, err)
 	assert.Nil(t, decD)

--- a/share/vss/pedersen/vss_test.go
+++ b/share/vss/pedersen/vss_test.go
@@ -205,7 +205,7 @@ func TestVSSVerifierDecryptDeal(t *testing.T) {
 
 	// wrong dh key
 	goodDh := encD.DHKey
-	encD.DHKey = suite.Point()
+	encD.DHKey, _ = suite.Point().Null().MarshalBinary()
 	decD, err = v.decryptDeal(encD)
 	assert.Error(t, err)
 	assert.Nil(t, decD)


### PR DESCRIPTION
This PR introduces a small and hopefully non-invasive change to make the Diffie Hellman key field a slice of bytes instead of point. The goal is to be able to translate the vss structs one-to-one into a protobuf packet. 
This introduces no additional marshallisation compared to what it was. It's also more consistent wrt the other fields such as signature which are all slice of bytes.
