### PR TITLE
TBLS Signature: use value receiver

### DIFF
--- a/sign/tbls/tbls.go
+++ b/sign/tbls/tbls.go
@@ -25,9 +25,9 @@ import (
 type SigShare []byte
 
 // Index returns the index i of the TBLS share Si.
-func (s *SigShare) Index() (int, error) {
+func (s SigShare) Index() (int, error) {
 	var index uint16
-	buf := bytes.NewReader(*s)
+	buf := bytes.NewReader(s)
 	err := binary.Read(buf, binary.BigEndian, &index)
 	if err != nil {
 		return -1, err


### PR DESCRIPTION
This change the `Index` method to value receiver. Using it that way makes it much more easier to convert from `[]byte` to `tbls.Signature` and allows constructions like `tbls.Signature(buff).Index()` which are not possible with the pointer receiver construction (since Golang can't get the address of a return variable directly).
Slices being only pointers, it does not copy anything of the actual data anyway.