### PR TITLE
BN256: g1 g2 gt being registered in all suites

### DIFF
--- a/pairing/bn256/group.go
+++ b/pairing/bn256/group.go
@@ -9,6 +9,7 @@ import (
 
 type groupG1 struct {
 	common
+	*commonSuite
 }
 
 func (g *groupG1) String() string {
@@ -25,6 +26,7 @@ func (g *groupG1) Point() kyber.Point {
 
 type groupG2 struct {
 	common
+	*commonSuite
 }
 
 func (g *groupG2) String() string {
@@ -41,6 +43,7 @@ func (g *groupG2) Point() kyber.Point {
 
 type groupGT struct {
 	common
+	*commonSuite
 }
 
 func (g *groupGT) String() string {

--- a/pairing/bn256/suite.go
+++ b/pairing/bn256/suite.go
@@ -16,29 +16,28 @@ import (
 
 // Suite implements the pairing.Suite interface for the BN256 bilinear pairing.
 type Suite struct {
+	*commonSuite
 	g1 *groupG1
 	g2 *groupG2
 	gt *groupGT
-	r  cipher.Stream
 }
 
 // NewSuite generates and returns a new BN256 pairing suite.
 func NewSuite() *Suite {
-	s := &Suite{}
-	s.g1 = &groupG1{}
-	s.g2 = &groupG2{}
-	s.gt = &groupGT{}
+	s := &Suite{commonSuite: &commonSuite{}}
+	s.g1 = &groupG1{commonSuite: s.commonSuite}
+	s.g2 = &groupG2{commonSuite: s.commonSuite}
+	s.gt = &groupGT{commonSuite: s.commonSuite}
 	return s
 }
 
 // NewSuiteRand generates and returns a new BN256 suite seeded by the
 // given cipher stream.
 func NewSuiteRand(rand cipher.Stream) *Suite {
-	s := &Suite{}
-	s.g1 = &groupG1{}
-	s.g2 = &groupG2{}
-	s.gt = &groupGT{}
-	s.r = rand
+	s := &Suite{commonSuite: &commonSuite{rand}}
+	s.g1 = &groupG1{commonSuite: s.commonSuite}
+	s.g2 = &groupG2{commonSuite: s.commonSuite}
+	s.gt = &groupGT{commonSuite: s.commonSuite}
 	return s
 }
 
@@ -63,35 +62,6 @@ func (s *Suite) Pair(p1 kyber.Point, p2 kyber.Point) kyber.Point {
 	return s.GT().Point().(*pointGT).Pair(p1, p2)
 }
 
-// Hash returns a newly instantiated sha256 hash function.
-func (s *Suite) Hash() hash.Hash {
-	return sha256.New()
-}
-
-// XOF returns a newlly instantiated blake2xb XOF function.
-func (s *Suite) XOF(seed []byte) kyber.XOF {
-	return blake2xb.New(seed)
-}
-
-// RandomStream returns a cipher.Stream which corresponds to a key stream from
-// crypto/rand.
-func (s *Suite) RandomStream() cipher.Stream {
-	if s.r != nil {
-		return s.r
-	}
-	return random.New()
-}
-
-// Read is the default implementation of kyber.Encoding interface Read.
-func (s *Suite) Read(r io.Reader, objs ...interface{}) error {
-	return fixbuf.Read(r, s, objs...)
-}
-
-// Write is the default implementation of kyber.Encoding interface Write.
-func (s *Suite) Write(w io.Writer, objs ...interface{}) error {
-	return fixbuf.Write(w, objs)
-}
-
 // Not used other than for reflect.TypeOf()
 var aScalar mod.Int
 var aPointG1 pointG1
@@ -103,17 +73,54 @@ var tPointG1 = reflect.TypeOf(&aPointG1).Elem()
 var tPointG2 = reflect.TypeOf(&aPointG2).Elem()
 var tPointGT = reflect.TypeOf(&aPointGT).Elem()
 
+type commonSuite struct {
+	s cipher.Stream
+}
+
 // New implements the kyber.Encoding interface.
-func (s *Suite) New(t reflect.Type) interface{} {
+func (c *commonSuite) New(t reflect.Type) interface{} {
 	switch t {
 	case tScalar:
-		return s.G1().Scalar()
+		g1 := groupG1{}
+		return g1.Scalar()
 	case tPointG1:
-		return s.G1().Point()
+		g1 := groupG1{}
+		return g1.Point()
 	case tPointG2:
-		return s.G2().Point()
+		g2 := groupG2{}
+		return g2.Point()
 	case tPointGT:
-		return s.GT().Point()
+		gt := groupGT{}
+		return gt.Point()
 	}
 	return nil
+}
+
+// Read is the default implementation of kyber.Encoding interface Read.
+func (c *commonSuite) Read(r io.Reader, objs ...interface{}) error {
+	return fixbuf.Read(r, c, objs...)
+}
+
+// Write is the default implementation of kyber.Encoding interface Write.
+func (c *commonSuite) Write(w io.Writer, objs ...interface{}) error {
+	return fixbuf.Write(w, objs)
+}
+
+// Hash returns a newly instantiated sha256 hash function.
+func (c *commonSuite) Hash() hash.Hash {
+	return sha256.New()
+}
+
+// XOF returns a newlly instantiated blake2xb XOF function.
+func (c *commonSuite) XOF(seed []byte) kyber.XOF {
+	return blake2xb.New(seed)
+}
+
+// RandomStream returns a cipher.Stream which corresponds to a key stream from
+// crypto/rand.
+func (c *commonSuite) RandomStream() cipher.Stream {
+	if c.s != nil {
+		return c.s
+	}
+	return random.New()
 }

--- a/suites/all.go
+++ b/suites/all.go
@@ -2,8 +2,13 @@ package suites
 
 import (
 	"github.com/dedis/kyber/group/edwards25519"
+	"github.com/dedis/kyber/pairing/bn256"
 )
 
 func init() {
 	register(edwards25519.NewBlakeSHA256Ed25519())
+	register(bn256.NewSuite().G1().(Suite))
+	register(bn256.NewSuite().G2().(Suite))
+	register(bn256.NewSuite().GT().(Suite))
+
 }

--- a/suites/all.go
+++ b/suites/all.go
@@ -2,8 +2,12 @@ package suites
 
 import (
 	"github.com/dedis/kyber/group/edwards25519"
+	"github.com/dedis/kyber/pairing/bn256"
 )
 
 func init() {
 	register(edwards25519.NewBlakeSHA256Ed25519())
+	register(bn256.NewSuite().G1().(Suite))
+	register(bn256.NewSuite().G2().(Suite))
+	register(bn256.NewSuite().GT().(Suite))
 }

--- a/suites/all.go
+++ b/suites/all.go
@@ -2,12 +2,8 @@ package suites
 
 import (
 	"github.com/dedis/kyber/group/edwards25519"
-	"github.com/dedis/kyber/pairing/bn256"
 )
 
 func init() {
 	register(edwards25519.NewBlakeSHA256Ed25519())
-	register(bn256.NewSuite().G1().(Suite))
-	register(bn256.NewSuite().G2().(Suite))
-	register(bn256.NewSuite().GT().(Suite))
 }

--- a/suites/all_vartime.go
+++ b/suites/all_vartime.go
@@ -5,7 +5,6 @@ package suites
 import (
 	"github.com/dedis/kyber/group/curve25519"
 	"github.com/dedis/kyber/group/nist"
-	"github.com/dedis/kyber/pairing/bn256"
 )
 
 func init() {
@@ -13,8 +12,4 @@ func init() {
 	register(curve25519.NewBlakeSHA256Curve25519(true))
 	register(nist.NewBlakeSHA256P256())
 	register(nist.NewBlakeSHA256QR512())
-	register(bn256.NewSuite().G1().(Suite))
-	register(bn256.NewSuite().G2().(Suite))
-	register(bn256.NewSuite().GT().(Suite))
-
 }

--- a/suites/all_vartime.go
+++ b/suites/all_vartime.go
@@ -5,6 +5,7 @@ package suites
 import (
 	"github.com/dedis/kyber/group/curve25519"
 	"github.com/dedis/kyber/group/nist"
+	"github.com/dedis/kyber/pairing/bn256"
 )
 
 func init() {
@@ -12,4 +13,8 @@ func init() {
 	register(curve25519.NewBlakeSHA256Curve25519(true))
 	register(nist.NewBlakeSHA256P256())
 	register(nist.NewBlakeSHA256QR512())
+	register(bn256.NewSuite().G1().(Suite))
+	register(bn256.NewSuite().G2().(Suite))
+	register(bn256.NewSuite().GT().(Suite))
+
 }


### PR DESCRIPTION
This PR augments bn256 g1 g2 and gt with some generic suite functionality so these groups can be registered as `Suite` in the global list of suites kyber has that can be referenced by name.
This is firstly motivated by the fact that it is currently not possible to run a simulation with bn256 for the moment since nothing is registered from this package. 