### PR TITLE
Point to build of master branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 [![Docs](https://img.shields.io/badge/docs-current-brightgreen.svg)](https://godoc.org/github.com/dedis/kyber)
-[![Build Status](https://travis-ci.org/dedis/kyber.svg)](https://travis-ci.org/dedis/kyber)
+[![Build Status](https://travis-ci.org/dedis/kyber.svg?branch=master)](https://travis-ci.org/dedis/kyber)
 
 DEDIS Advanced Crypto Library for Go
 ====================================


### PR DESCRIPTION
Instead of showing latest build of any branch, only show master branch.