### PR TITLE
Changed marshalBinary to be thread safe

### DIFF
--- a/encoding.go
+++ b/encoding.go
@@ -9,6 +9,9 @@ import (
 /*
 Marshaling is a basic interface representing fixed-length (or known-length)
 cryptographic objects or structures having a built-in binary encoding.
+Implementors must ensure that calls to these methods do not modify
+the underlying object so that other users of the object can access
+it concurrently.
 */
 type Marshaling interface {
 	encoding.BinaryMarshaler

--- a/pairing/bn256/point.go
+++ b/pairing/bn256/point.go
@@ -108,6 +108,8 @@ func (p *pointG1) Mul(s kyber.Scalar, q kyber.Point) kyber.Point {
 
 func (p *pointG1) MarshalBinary() ([]byte, error) {
 	n := p.ElementSize()
+	// Take a copy so that p is not written to, so calls to MarshalBinary
+	// are threadsafe.
 	pgtemp := *p.g
 	pgtemp.MakeAffine()
 	ret := make([]byte, p.MarshalSize())

--- a/pairing/bn256/point.go
+++ b/pairing/bn256/point.go
@@ -108,15 +108,16 @@ func (p *pointG1) Mul(s kyber.Scalar, q kyber.Point) kyber.Point {
 
 func (p *pointG1) MarshalBinary() ([]byte, error) {
 	n := p.ElementSize()
-	p.g.MakeAffine()
+	pgtemp := *p.g
+	pgtemp.MakeAffine()
 	ret := make([]byte, p.MarshalSize())
-	if p.g.IsInfinity() {
+	if pgtemp.IsInfinity() {
 		return ret, nil
 	}
 	tmp := &gfP{}
-	montDecode(tmp, &p.g.x)
+	montDecode(tmp, &pgtemp.x)
 	tmp.Marshal(ret)
-	montDecode(tmp, &p.g.y)
+	montDecode(tmp, &pgtemp.y)
 	tmp.Marshal(ret[n:])
 	return ret, nil
 }


### PR DESCRIPTION
Dear dedis friends,

I discussed this morning with Linus and Kelong and to prevent some race conditions (for example when marshalling the roster public key with parallel sends) we changed the MarshalBinary() to be thread safe by using a copy of the point instead of the point itself. 

@Daeinar please let me know if you agree with this change :)