### PR TITLE
Publish proof and shuffle as stable.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,4 +15,4 @@ entry_tunnel
 exit_tunnel
 .DS_Store
 *.cov
-
+.idea

--- a/proof/clique.go
+++ b/proof/clique.go
@@ -1,14 +1,13 @@
 package proof
 
-// A clique protocol is a kyber.on for a cryptographic protocol
+// A clique protocol is a cryptographic protocol
 // in which every participant knows about and interacts directly
 // in lock-step with every other participant in the clique.
 // Clique protocols are suitable for small-scale groups,
 // such as "boards of trustees" chosen from larger groups.
 //
-// The basic clique protocol
-// assumes that nodes are always "live" and never go offline,
-// but we can achieve availability via threshold kyber.
+// The basic clique protocol assumes that nodes are always "live" and
+// never go offline, but we can achieve availability via threshold crypto.
 
 import "github.com/dedis/kyber"
 
@@ -17,7 +16,6 @@ import "github.com/dedis/kyber"
 // which invokes the StarContext's methods to send and receive messages,
 // and finally returns once the protocol has concluded for all participants.
 // Returns a slice of success/error indicators, one for each participant.
-//
 type Protocol func(ctx Context) []error
 
 // Context represents a kyber.context for running a clique protocol.
@@ -30,7 +28,6 @@ type Protocol func(ctx Context) []error
 // Followers can drop out or be absent at any step, in which case
 // they are seen as contributing an empty message in that step.
 type Context interface {
-
 	// A follower calls Step to provide its message for the next step,
 	// and wait for the leader to collect and distribute all messages.
 	// Returns the list of collected messages, one per participant.

--- a/proof/context.go
+++ b/proof/context.go
@@ -15,7 +15,7 @@ type Prover func(ctx ProverContext) error
 // and returns nil on success or an error once the protocol run concludes.
 type Verifier func(ctx VerifierContext) error
 
-// ProverContext represents the kyber.environment
+// ProverContext represents the environment
 // required by the prover in a Sigma protocol.
 //
 // In a basic 3-step Sigma protocol such as a standard digital signature,
@@ -39,7 +39,7 @@ type ProverContext interface {
 	PriRand(message ...interface{}) error // Get private randomness
 }
 
-// VerifierContext represents the kyber.environment
+// VerifierContext represents the environment
 // required by the verifier in a Sigma protocol.
 //
 // The verifier calls Get() to obtain the prover's message data,

--- a/shuffle/pair.go
+++ b/shuffle/pair.go
@@ -30,7 +30,7 @@ import (
 )
 
 // Suite wraps the functionalities needed by the shuffle/ package. These are the
-// same functionatlities needed by the proof/ package.
+// same functionalities needed by the proof/ package.
 type Suite proof.Suite
 
 // XX these could all be inlined into PairShuffleProof; do we want to?

--- a/stable/directories
+++ b/stable/directories
@@ -7,6 +7,7 @@ group/internal/marshalling
 group/mod
 group/nist
 proof/dleq
+proof
 share
 share/dkg/rabin
 share/dkg/pedersen
@@ -19,6 +20,7 @@ sign/cosi
 sign/eddsa
 sign/eddsa/testdata
 sign/schnorr
+shuffle
 suites
 util/encoding
 util/key


### PR DESCRIPTION
Package shuffle is currently used in PriFi and e-voting, so
they must be stable enough.

Shuffle depends on proof, so it must also be stable.

Also: Slight improvements to proof docs.