### PR TITLE
Don't panic in group tests

### DIFF
--- a/group/curve25519/basic_test.go
+++ b/group/curve25519/basic_test.go
@@ -14,7 +14,7 @@ func TestBasic25519(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping test in short mode.")
 	} else {
-		test.GroupTest(new(BasicCurve).Init(Param25519(), false))
+		test.GroupTest(t, new(BasicCurve).Init(Param25519(), false))
 	}
 }
 
@@ -24,7 +24,7 @@ func TestCompareBasicProjective25519(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping test in short mode.")
 	} else {
-		test.CompareGroups(testSuite.XOF,
+		test.CompareGroups(t, testSuite.XOF,
 			new(BasicCurve).Init(Param25519(), false),
 			new(ProjectiveCurve).Init(Param25519(), false))
 	}
@@ -34,7 +34,7 @@ func TestCompareBasicProjectiveE382(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping test in short mode.")
 	} else {
-		test.CompareGroups(testSuite.XOF,
+		test.CompareGroups(t, testSuite.XOF,
 			new(BasicCurve).Init(ParamE382(), false),
 			new(ProjectiveCurve).Init(ParamE382(), false))
 	}
@@ -44,7 +44,7 @@ func TestCompareBasicProjective41417(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping test in short mode.")
 	} else {
-		test.CompareGroups(testSuite.XOF,
+		test.CompareGroups(t, testSuite.XOF,
 			new(BasicCurve).Init(Param41417(), false),
 			new(ProjectiveCurve).Init(Param41417(), false))
 	}
@@ -54,7 +54,7 @@ func TestCompareBasicProjectiveE521(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping test in short mode.")
 	} else {
-		test.CompareGroups(testSuite.XOF,
+		test.CompareGroups(t, testSuite.XOF,
 			new(BasicCurve).Init(ParamE521(), false),
 			new(ProjectiveCurve).Init(ParamE521(), false))
 	}

--- a/group/curve25519/curve_test.go
+++ b/group/curve25519/curve_test.go
@@ -16,37 +16,37 @@ var testSuite = NewBlakeSHA256Curve25519(false)
 // Test each curve implementation of the Ed25519 curve.
 
 func TestProjective25519(t *testing.T) {
-	test.GroupTest(new(ProjectiveCurve).Init(Param25519(), false))
+	test.GroupTest(t, new(ProjectiveCurve).Init(Param25519(), false))
 }
 
 func TestExtended25519(t *testing.T) {
-	test.GroupTest(new(ExtendedCurve).Init(Param25519(), false))
+	test.GroupTest(t, new(ExtendedCurve).Init(Param25519(), false))
 }
 
 func TestEd25519(t *testing.T) {
-	test.GroupTest(new(edwards25519.Curve))
+	test.GroupTest(t, new(edwards25519.Curve))
 }
 
 // Test the Extended coordinates implementation of each curve.
 
 func Test1174(t *testing.T) {
-	test.GroupTest(new(ExtendedCurve).Init(Param1174(), false))
+	test.GroupTest(t, new(ExtendedCurve).Init(Param1174(), false))
 }
 
 func Test25519(t *testing.T) {
-	test.GroupTest(new(ExtendedCurve).Init(Param25519(), false))
+	test.GroupTest(t, new(ExtendedCurve).Init(Param25519(), false))
 }
 
 func TestE382(t *testing.T) {
-	test.GroupTest(new(ExtendedCurve).Init(ParamE382(), false))
+	test.GroupTest(t, new(ExtendedCurve).Init(ParamE382(), false))
 }
 
 func Test4147(t *testing.T) {
-	test.GroupTest(new(ExtendedCurve).Init(Param41417(), false))
+	test.GroupTest(t, new(ExtendedCurve).Init(Param41417(), false))
 }
 
 func TestE521(t *testing.T) {
-	test.GroupTest(new(ExtendedCurve).Init(ParamE521(), false))
+	test.GroupTest(t, new(ExtendedCurve).Init(ParamE521(), false))
 }
 
 func TestSetBytesBE(t *testing.T) {
@@ -64,54 +64,54 @@ func TestSetBytesBE(t *testing.T) {
 // for which a full-group-order base point is defined.
 
 func TestFullOrder1174(t *testing.T) {
-	test.GroupTest(new(ExtendedCurve).Init(Param1174(), true))
+	test.GroupTest(t, new(ExtendedCurve).Init(Param1174(), true))
 }
 
 func TestFullOrder25519(t *testing.T) {
-	test.GroupTest(new(ExtendedCurve).Init(Param25519(), true))
+	test.GroupTest(t, new(ExtendedCurve).Init(Param25519(), true))
 }
 
 func TestFullOrderE382(t *testing.T) {
-	test.GroupTest(new(ExtendedCurve).Init(ParamE382(), true))
+	test.GroupTest(t, new(ExtendedCurve).Init(ParamE382(), true))
 }
 
 func TestFullOrder4147(t *testing.T) {
-	test.GroupTest(new(ExtendedCurve).Init(Param41417(), true))
+	test.GroupTest(t, new(ExtendedCurve).Init(Param41417(), true))
 }
 
 func TestFullOrderE521(t *testing.T) {
-	test.GroupTest(new(ExtendedCurve).Init(ParamE521(), true))
+	test.GroupTest(t, new(ExtendedCurve).Init(ParamE521(), true))
 }
 
 // Test ExtendedCurve versus ProjectiveCurve implementations
 
 func TestCompareProjectiveExtended25519(t *testing.T) {
-	test.CompareGroups(testSuite.XOF,
+	test.CompareGroups(t, testSuite.XOF,
 		new(ProjectiveCurve).Init(Param25519(), false),
 		new(ExtendedCurve).Init(Param25519(), false))
 }
 
 func TestCompareProjectiveExtendedE382(t *testing.T) {
-	test.CompareGroups(testSuite.XOF,
+	test.CompareGroups(t, testSuite.XOF,
 		new(ProjectiveCurve).Init(ParamE382(), false),
 		new(ExtendedCurve).Init(ParamE382(), false))
 }
 
 func TestCompareProjectiveExtended41417(t *testing.T) {
-	test.CompareGroups(testSuite.XOF,
+	test.CompareGroups(t, testSuite.XOF,
 		new(ProjectiveCurve).Init(Param41417(), false),
 		new(ExtendedCurve).Init(Param41417(), false))
 }
 
 func TestCompareProjectiveExtendedE521(t *testing.T) {
-	test.CompareGroups(testSuite.XOF,
+	test.CompareGroups(t, testSuite.XOF,
 		new(ProjectiveCurve).Init(ParamE521(), false),
 		new(ExtendedCurve).Init(ParamE521(), false))
 }
 
 // Test Ed25519 versus ExtendedCurve implementations of Curve25519.
 func TestCompareEd25519(t *testing.T) {
-	test.CompareGroups(testSuite.XOF,
+	test.CompareGroups(t, testSuite.XOF,
 		new(ExtendedCurve).Init(Param25519(), false),
 		new(edwards25519.Curve))
 }

--- a/group/edwards25519/curve_test.go
+++ b/group/edwards25519/curve_test.go
@@ -9,7 +9,7 @@ import (
 var tSuite = NewBlakeSHA256Ed25519()
 var groupBench = test.NewGroupBench(tSuite)
 
-func TestSuite(t *testing.T) { test.SuiteTest(tSuite) }
+func TestSuite(t *testing.T) { test.SuiteTest(t, tSuite) }
 
 func BenchmarkScalarAdd(b *testing.B)    { groupBench.ScalarAdd(b.N) }
 func BenchmarkScalarSub(b *testing.B)    { groupBench.ScalarSub(b.N) }

--- a/group/nist/group_test.go
+++ b/group/nist/group_test.go
@@ -10,11 +10,11 @@ import (
 
 var testQR512 = NewBlakeSHA256QR512()
 
-func TestQR512(t *testing.T) { test.SuiteTest(testQR512) }
+func TestQR512(t *testing.T) { test.SuiteTest(t, testQR512) }
 
 var testP256 = NewBlakeSHA256P256()
 
-func TestP256(t *testing.T) { test.SuiteTest(testP256) }
+func TestP256(t *testing.T) { test.SuiteTest(t, testP256) }
 
 func TestSetBytesBE(t *testing.T) {
 	s := testP256.Scalar()

--- a/util/test/test.go
+++ b/util/test/test.go
@@ -3,6 +3,7 @@ package test
 import (
 	"bytes"
 	"crypto/cipher"
+	"testing"
 
 	"github.com/dedis/kyber"
 	"github.com/dedis/kyber/util/key"
@@ -33,7 +34,7 @@ func (ss *suiteStable) RandomStream() cipher.Stream {
 	return ss.xof
 }
 
-func testEmbed(g kyber.Group, rand cipher.Stream, points *[]kyber.Point,
+func testEmbed(t *testing.T, g kyber.Group, rand cipher.Stream, points *[]kyber.Point,
 	s string) {
 	// println("embedding: ", s)
 	b := []byte(s)
@@ -41,7 +42,7 @@ func testEmbed(g kyber.Group, rand cipher.Stream, points *[]kyber.Point,
 	p := g.Point().Embed(b, rand)
 	x, err := p.Data()
 	if err != nil {
-		panic("Point extraction failed: " + err.Error())
+		t.Errorf("Point extraction failed for %v: %v", p, err)
 	}
 	//println("extracted data (", len(x), " bytes): ", string(x))
 	//println("EmbedLen(): ", g.Point().EmbedLen())
@@ -50,13 +51,13 @@ func testEmbed(g kyber.Group, rand cipher.Stream, points *[]kyber.Point,
 		max = len(b)
 	}
 	if !bytes.Equal(append(x, b[max:]...), b) {
-		panic("Point embedding corrupted the data")
+		t.Errorf("Point embedding corrupted the data")
 	}
 
 	*points = append(*points, p)
 }
 
-func testPointSet(g kyber.Group, rand cipher.Stream) {
+func testPointSet(t *testing.T, g kyber.Group, rand cipher.Stream) {
 	N := 1000
 	null := g.Point().Null()
 	for i := 0; i < N; i++ {
@@ -64,67 +65,68 @@ func testPointSet(g kyber.Group, rand cipher.Stream) {
 		P2 := g.Point()
 		P2.Set(P1)
 		if !P1.Equal(P2) {
-			panic("Set() set to a different point.")
+			t.Errorf("Set() set to a different point: %v != %v", P1, P2)
 		}
 		if !P1.Equal(null) {
 			P1.Add(P1, P1)
 			if P1.Equal(P2) {
-				panic("Modifying P1 shouldn't modify P2")
+				t.Errorf("Modifying P1 shouldn't modify P2: %v == %v", P1, P2)
 			}
 		}
 	}
 }
 
-func testPointClone(g kyber.Group, rand cipher.Stream) {
+func testPointClone(t *testing.T, g kyber.Group, rand cipher.Stream) {
 	N := 1000
 	null := g.Point().Null()
 	for i := 0; i < N; i++ {
 		P1 := g.Point().Pick(rand)
 		P2 := P1.Clone()
 		if !P1.Equal(P2) {
-			panic("Clone didn't create a point with same " +
-				"coordinates as the original point.")
+			t.Errorf("Clone didn't work for point: %v != %v", P1, P2)
 		}
 		if !P1.Equal(null) {
 			P1.Add(P1, P1)
 			if P1.Equal(P2) {
-				panic("Modifying P1 shouldn't modify P2")
+				t.Errorf("Modifying P1 shouldn't modify P2: %v == %v", P1, P2)
 			}
 		}
 	}
 }
 
-func testScalarSet(g kyber.Group, rand cipher.Stream) {
+func testScalarSet(t *testing.T, g kyber.Group, rand cipher.Stream) {
 	N := 1000
+	zero := g.Scalar().Zero()
 	one := g.Scalar().One()
 	for i := 0; i < N; i++ {
 		s1 := g.Scalar().Pick(rand)
 		s2 := g.Scalar().Set(s1)
 		if !s1.Equal(s2) {
-			panic("Clone didn't create a scalar s2 with same value as s1's.")
+			t.Errorf("Set() set to a different scalar: %v != %v", s1, s2)
 		}
-		if !s1.Equal(one) {
+		if !s1.Equal(zero) && !s1.Equal(one) {
 			s1.Mul(s1, s1)
 			if s1.Equal(s2) {
-				panic("Modifying s1 shouldn't modify s2")
+				t.Errorf("Modifying s1 shouldn't modify s2: %v == %v", s1, s2)
 			}
 		}
 	}
 }
 
-func testScalarClone(g kyber.Group, rand cipher.Stream) {
+func testScalarClone(t *testing.T, g kyber.Group, rand cipher.Stream) {
 	N := 1000
+	zero := g.Scalar().Zero()
 	one := g.Scalar().One()
 	for i := 0; i < N; i++ {
 		s1 := g.Scalar().Pick(rand)
 		s2 := s1.Clone()
 		if !s1.Equal(s2) {
-			panic("Clone didn't create a scalar s2 with same value as s1's.")
+			t.Errorf("Clone didn't work for scalar: %v != %v", s1, s2)
 		}
-		if !s1.Equal(one) {
+		if !s1.Equal(zero) && !s1.Equal(one) {
 			s1.Mul(s1, s1)
 			if s1.Equal(s2) {
-				panic("Modifying s1 shouldn't modify s2")
+				t.Errorf("Modifying s1 shouldn't modify s2: %v == %v", s1, s2)
 			}
 		}
 	}
@@ -137,9 +139,9 @@ func testScalarClone(g kyber.Group, rand cipher.Stream) {
 // for comparison across alternative implementations
 // that are supposed to be equivalent.
 //
-func testGroup(g kyber.Group, rand cipher.Stream) []kyber.Point {
-	//	fmt.Printf("\nTesting group '%s': %d-byte Point, %d-byte Scalar\n",
-	//			g.String(), g.PointLen(), g.ScalarLen())
+func testGroup(t *testing.T, g kyber.Group, rand cipher.Stream) []kyber.Point {
+	t.Logf("\nTesting group '%s': %d-byte Point, %d-byte Scalar\n",
+		g.String(), g.PointLen(), g.ScalarLen())
 
 	points := make([]kyber.Point, 0)
 	ptmp := g.Point()
@@ -152,7 +154,7 @@ func testGroup(g kyber.Group, rand cipher.Stream) []kyber.Point {
 	s1 := g.Scalar().Pick(rand)
 	s2 := g.Scalar().Pick(rand)
 	if s1.Equal(s2) {
-		panic("uh-oh, not getting unique secrets!")
+		t.Errorf("not getting unique secrets: picked %s twice", s1)
 	}
 
 	gen := g.Point().Base()
@@ -162,12 +164,13 @@ func testGroup(g kyber.Group, rand cipher.Stream) []kyber.Point {
 	p1 := g.Point().Add(gen, gen)
 	p2 := g.Point().Mul(stmp.SetInt64(2), nil)
 	if !p1.Equal(p2) {
-		panic("oops, multiply by two doesn't work")
+		t.Errorf("multiply by two doesn't work: %v == %v (+) %[2]v != %[2]v (x) 2 == %v", p1, gen, p2)
 	}
 	p1.Add(p1, p1)
 	p2.Mul(stmp.SetInt64(4), nil)
 	if !p1.Equal(p2) {
-		panic("oops, multiply by four doesn't work")
+		t.Errorf("multiply by four doesn't work: %v (+) %[1]v != %v (x) 4 == %v",
+			g.Point().Add(gen, gen), gen, p2)
 	}
 	points = append(points, p1)
 
@@ -185,46 +188,51 @@ func testGroup(g kyber.Group, rand cipher.Stream) []kyber.Point {
 	// Verify additive and multiplicative identities of the generator.
 	ptmp.Mul(stmp.SetInt64(-1), nil).Add(ptmp, gen)
 	if !ptmp.Equal(pzero) {
-		panic("oops, generator additive identity doesn't work")
+		t.Errorf("generator additive identity doesn't work: %v (x) -1 (+) %v != %v the group point identity",
+			ptmp.Mul(stmp.SetInt64(-1), nil), gen, pzero)
 	}
 	// secret.Inv works only in prime-order groups
 	if primeOrder {
 		ptmp.Mul(stmp.SetInt64(2), nil).Mul(stmp.Inv(stmp), ptmp)
 		if !ptmp.Equal(gen) {
-			panic("oops, generator multiplicative identity doesn't work")
+			t.Errorf("generator multiplicative identity doesn't work:\n%v (x) %v = %v\n%[3]v (x) %v = %v",
+				ptmp.Base().String(), stmp.SetInt64(2).String(),
+				ptmp.Mul(stmp.SetInt64(2), nil).String(),
+				stmp.Inv(stmp).String(),
+				ptmp.Mul(stmp.SetInt64(2), nil).Mul(stmp.Inv(stmp), ptmp).String())
 		}
 	}
 
 	p1.Mul(s1, gen)
 	p2.Mul(s2, gen)
 	if p1.Equal(p2) {
-		panic("uh-oh, encryption isn't producing unique points!")
+		t.Errorf("encryption isn't producing unique points: %v (x) %v == %v (x) %[2]v == %[4]v", s1, gen, s2, p1)
 	}
 	points = append(points, p1)
 
 	dh1 := g.Point().Mul(s2, p1)
 	dh2 := g.Point().Mul(s1, p2)
 	if !dh1.Equal(dh2) {
-		panic("Diffie-Hellman didn't work")
+		t.Errorf("Diffie-Hellman didn't work: %v == %v (x) %v != %v (x) %v == %v", dh1, s2, p1, s1, p2, dh2)
 	}
 	points = append(points, dh1)
-	//println("shared secret = ",dh1.String())
+	t.Logf("shared secret = %v", dh1)
 
 	// Test secret inverse to get from dh1 back to p1
 	if primeOrder {
 		ptmp.Mul(g.Scalar().Inv(s2), dh1)
 		if !ptmp.Equal(p1) {
-			panic("Scalar inverse didn't work")
+			t.Errorf("Scalar inverse didn't work: %v != (-)%v (x) %v == %v", p1, s2, dh1, ptmp)
 		}
 	}
 
 	// Zero and One identity secrets
 	//println("dh1^0 = ",ptmp.Mul(dh1, szero).String())
 	if !ptmp.Mul(szero, dh1).Equal(pzero) {
-		panic("Encryption with secret=0 didn't work")
+		t.Errorf("Encryption with secret=0 didn't work: %v (x) %v == %v != %v", szero, dh1, ptmp, pzero)
 	}
 	if !ptmp.Mul(sone, dh1).Equal(dh1) {
-		panic("Encryption with secret=1 didn't work")
+		t.Errorf("Encryption with secret=1 didn't work: %v (x) %v == %v != %[2]v", sone, dh1, ptmp)
 	}
 
 	// Additive homomorphic identities
@@ -232,38 +240,45 @@ func testGroup(g kyber.Group, rand cipher.Stream) []kyber.Point {
 	stmp.Add(s1, s2)
 	pt2 := g.Point().Mul(stmp, gen)
 	if !pt2.Equal(ptmp) {
-		panic("Additive homomorphism doesn't work")
+		t.Errorf("Additive homomorphism doesn't work: %v + %v == %v, %[3]v (x) %v == %v != %v == %v (+) %v",
+			s1, s2, stmp, gen, pt2, ptmp, p1, p2)
 	}
 	ptmp.Sub(p1, p2)
 	stmp.Sub(s1, s2)
 	pt2.Mul(stmp, gen)
 	if !pt2.Equal(ptmp) {
-		panic("Additive homomorphism doesn't work")
+		t.Errorf("Additive homomorphism doesn't work: %v - %v == %v, %[3]v (x) %v == %v != %v == %v (-) %v",
+			s1, s2, stmp, gen, pt2, ptmp, p1, p2)
 	}
 	st2 := g.Scalar().Neg(s2)
 	st2.Add(s1, st2)
 	if !stmp.Equal(st2) {
-		panic("Scalar.Neg doesn't work")
+		t.Errorf("Scalar.Neg doesn't work: -%v == %v, %[2]v + %v == %v != %v",
+			s2, g.Scalar().Neg(s2), s1, st2, stmp)
 	}
 	pt2.Neg(p2).Add(pt2, p1)
 	if !pt2.Equal(ptmp) {
-		panic("Point.Neg doesn't work")
+		t.Errorf("Point.Neg doesn't work: (-)%v == %v, %[2]v (+) %v == %v != %v",
+			p2, g.Point().Neg(p2), p1, pt2, ptmp)
 	}
 
 	// Multiplicative homomorphic identities
 	stmp.Mul(s1, s2)
 	if !ptmp.Mul(stmp, gen).Equal(dh1) {
-		panic("Multiplicative homomorphism doesn't work")
+		t.Errorf("Multiplicative homomorphism doesn't work: %v * %v == %v, %[2]v (x) %v == %v != %v",
+			s1, s2, stmp, gen, ptmp, dh1)
 	}
 	if primeOrder {
 		st2.Inv(s2)
 		st2.Mul(st2, stmp)
 		if !st2.Equal(s1) {
-			panic("Scalar division doesn't work")
+			t.Errorf("Scalar division doesn't work: %v^-1 * %v == %v * %[2]v == %[4]v != %v",
+				s2, stmp, g.Scalar().Inv(s2), st2, s1)
 		}
 		st2.Div(stmp, s2)
 		if !st2.Equal(s1) {
-			panic("Scalar division doesn't work")
+			t.Errorf("Scalar division doesn't work: %v / %v == %v != %v",
+				stmp, s2, st2, s1)
 		}
 	}
 
@@ -272,26 +287,29 @@ func testGroup(g kyber.Group, rand cipher.Stream) []kyber.Point {
 	for i := 0; i < 5; i++ {
 		rgen := g.Point().Pick(rand)
 		if rgen.Equal(last) {
-			panic("Pick() not producing unique points")
+			t.Errorf("Pick() not producing unique points: got %v twice", rgen)
 		}
 		last = rgen
 
 		ptmp.Mul(stmp.SetInt64(-1), rgen).Add(ptmp, rgen)
 		if !ptmp.Equal(pzero) {
-			panic("random generator fails additive identity")
+			t.Errorf("random generator fails additive identity: %v (x) %v == %v, %v (+) %[3]v == %[5]v != %v",
+				g.Scalar().SetInt64(-1), rgen, g.Point().Mul(g.Scalar().SetInt64(-1), rgen),
+				rgen, g.Point().Mul(g.Scalar().SetInt64(-1), rgen), pzero)
 		}
 		if primeOrder {
 			ptmp.Mul(stmp.SetInt64(2), rgen).Mul(stmp.Inv(stmp), ptmp)
 			if !ptmp.Equal(rgen) {
-				panic("random generator fails multiplicative identity")
+				t.Errorf("random generator fails multiplicative identity: %v (x) (2 (x) %v) == %v != %[2]v",
+					stmp, rgen, ptmp)
 			}
 		}
 		points = append(points, rgen)
 	}
 
 	// Test embedding data
-	testEmbed(g, rand, &points, "Hi!")
-	testEmbed(g, rand, &points, "The quick brown fox jumps over the lazy dog")
+	testEmbed(t, g, rand, &points, "Hi!")
+	testEmbed(t, g, rand, &points, "The quick brown fox jumps over the lazy dog")
 
 	// Test verifiable secret sharing
 
@@ -301,25 +319,25 @@ func testGroup(g kyber.Group, rand cipher.Stream) []kyber.Point {
 		buf.Reset()
 		s := g.Scalar().Pick(rand)
 		if _, err := s.MarshalTo(buf); err != nil {
-			panic("encoding of secret fails: " + err.Error())
+			t.Errorf("encoding of secret fails: " + err.Error())
 		}
 		if _, err := stmp.UnmarshalFrom(buf); err != nil {
-			panic("decoding of secret fails: " + err.Error())
+			t.Errorf("decoding of secret fails: " + err.Error())
 		}
 		if !stmp.Equal(s) {
-			panic("decoding produces different secret than encoded")
+			t.Errorf("decoding produces different secret than encoded")
 		}
 
 		buf.Reset()
 		p := g.Point().Pick(rand)
 		if _, err := p.MarshalTo(buf); err != nil {
-			panic("encoding of point fails: " + err.Error())
+			t.Errorf("encoding of point fails: " + err.Error())
 		}
 		if _, err := ptmp.UnmarshalFrom(buf); err != nil {
-			panic("decoding of point fails: " + err.Error())
+			t.Errorf("decoding of point fails: " + err.Error())
 		}
 		if !ptmp.Equal(p) {
-			panic("decoding produces different point than encoded")
+			t.Errorf("decoding produces different point than encoded")
 		}
 	}
 
@@ -329,45 +347,43 @@ func testGroup(g kyber.Group, rand cipher.Stream) []kyber.Point {
 	repzero := g.Point()
 	err := repzero.UnmarshalBinary(b)
 	if err != nil {
-		panic(err)
+		t.Errorf("Could not unmarshall binary %v: %v", b, err)
 	}
 
-	testPointSet(g, rand)
-	testPointClone(g, rand)
-	testScalarSet(g, rand)
-	testScalarClone(g, rand)
+	testPointSet(t, g, rand)
+	testPointClone(t, g, rand)
+	testScalarSet(t, g, rand)
+	testScalarClone(t, g, rand)
 
 	return points
 }
 
 // GroupTest applies a generic set of validation tests to a cryptographic Group.
-func GroupTest(g kyber.Group) {
-	testGroup(g, random.New())
+func GroupTest(t *testing.T, g kyber.Group) {
+	testGroup(t, g, random.New())
 }
 
 // CompareGroups tests two group implementations that are supposed to be equivalent,
 // and compare their results.
-func CompareGroups(fn func(key []byte) kyber.XOF, g1, g2 kyber.Group) {
+func CompareGroups(t *testing.T, fn func(key []byte) kyber.XOF, g1, g2 kyber.Group) {
 
 	// Produce test results from the same pseudorandom seed
-	r1 := testGroup(g1, fn(nil))
-	r2 := testGroup(g2, fn(nil))
+	r1 := testGroup(t, g1, fn(nil))
+	r2 := testGroup(t, g2, fn(nil))
 
 	// Compare resulting Points
 	for i := range r1 {
 		b1, _ := r1[i].MarshalBinary()
 		b2, _ := r2[i].MarshalBinary()
 		if !bytes.Equal(b1, b2) {
-			println("result-pair", i,
-				"\n1:", r1[i].String(),
-				"\n2:", r2[i].String())
-			panic("unequal results")
+			t.Errorf("unequal result-pair %v\n1: %v\n2: %v",
+				i, r1[i], r2[i])
 		}
 	}
 }
 
 // SuiteTest tests a standard set of validation tests to a ciphersuite.
-func SuiteTest(suite suite) {
+func SuiteTest(t *testing.T, suite suite) {
 
 	// Try hashing something
 	h := suite.Hash()
@@ -379,7 +395,7 @@ func SuiteTest(suite suite) {
 	//println("Hash:")
 	//println(hex.Dump(hb))
 	if h.Size() != l || len(hb) != l {
-		panic("inconsistent hash output length")
+		t.Errorf("inconsistent hash output length: %v vs %v vs %v", l, h.Size(), len(hb))
 	}
 
 	// Generate some pseudorandom bits
@@ -393,7 +409,7 @@ func SuiteTest(suite suite) {
 	p1 := key.NewKeyPair(suite)
 	p2 := key.NewKeyPair(suite)
 	if p1.Private.Equal(p2.Private) {
-		panic("NewKeyPair returns the same secret key twice")
+		t.Errorf("NewKeyPair returns the same secret key twice: %v", p1)
 	}
 
 	// Test if it creates the same key with the same seed
@@ -403,9 +419,9 @@ func SuiteTest(suite suite) {
 	p1.Gen(newSuiteStable(suite))
 	p2.Gen(newSuiteStable(suite))
 	if !p1.Private.Equal(p2.Private) {
-		panic("NewKeyPair returns different keys for same seed")
+		t.Errorf("NewKeyPair returns different keys for same seed: %v != %v", p1, p2)
 	}
 
 	// Test the public-key group arithmetic
-	GroupTest(suite)
+	GroupTest(t, suite)
 }

--- a/util/test/test.go
+++ b/util/test/test.go
@@ -153,6 +153,12 @@ func testGroup(t *testing.T, g kyber.Group, rand cipher.Stream) []kyber.Point {
 	// Do a simple Diffie-Hellman test
 	s1 := g.Scalar().Pick(rand)
 	s2 := g.Scalar().Pick(rand)
+	if s1.Equal(szero) {
+		t.Errorf("first secret is scalar zero %v", s1)
+	}
+	if s2.Equal(szero) {
+		t.Errorf("second secret is scalar zero %v", s2)
+	}
 	if s1.Equal(s2) {
 		t.Errorf("not getting unique secrets: picked %s twice", s1)
 	}


### PR DESCRIPTION
This injects `t *testing.T` into the `GroupTest`s and uses it to allow tests to continue after individual failures, and for tests to report extra info on specific failure cases.