### PR TITLE
Refresh DKG Shares Test

### DIFF
--- a/share/poly_test.go
+++ b/share/poly_test.go
@@ -392,7 +392,6 @@ func TestRefreshDKG(test *testing.T) {
 
 	// Handout shares to new nodes column-wise and verify them
 	newDKGShares := make([]*PriShare, n)
-	newDKGCommits := make([]kyber.Point, t)
 	for i := 0; i < n; i++ {
 		tmpPriShares := make([]*PriShare, n) // column-wise reshuffled sub-shares
 		tmpPubShares := make([]*PubShare, n) // public commitments to old DKG private shares
@@ -420,6 +419,7 @@ func TestRefreshDKG(test *testing.T) {
 	}
 
 	// Refresh the DKG commitments (= verification vector)
+	newDKGCommits := make([]kyber.Point, t)
 	for i := 0; i < t; i++ {
 		pubShares := make([]*PubShare, n)
 		for j := 0; j < n; j++ {

--- a/share/poly_test.go
+++ b/share/poly_test.go
@@ -324,7 +324,7 @@ func TestRefreshDKG(test *testing.T) {
 	n := 10
 	t := n/2 + 1
 
-	// Run an (n-fold Pedersen) VSS
+	// Run an n-fold Pedersen VSS (= DKG)
 	priPolys := make([]*PriPoly, n)
 	priShares := make([][]*PriShare, n)
 	pubPolys := make([]*PubPoly, n)


### PR DESCRIPTION
This PR contains two things:
- It fixes a small bug in the secret sharing code where too many values were taken during Lagrange interpolation.
- It adds a test showing how to refresh DKG shares as presented in the paper "Verifiable Secret Redistribution for Archive Systems".