### PR TITLE
Fix some documentation typos

### DIFF
--- a/group.go
+++ b/group.go
@@ -4,7 +4,7 @@ import (
 	"crypto/cipher"
 )
 
-// A Scalar kyber.y represents a scalar value by which
+// Scalar represents a scalar value by which
 // a Point (group element) may be encrypted to produce another Point.
 // This is an exponent in DSA-style groups,
 // in which security is based on the Discrete Logarithm assumption,
@@ -12,43 +12,43 @@ import (
 type Scalar interface {
 	Marshaling
 
-	// Equality test for two Scalars derived from the same Group
+	// Equality test for two Scalars derived from the same Group.
 	Equal(s2 Scalar) bool
 
-	// Set sets the receiver equal to another Scalar a
+	// Set sets the receiver equal to another Scalar a.
 	Set(a Scalar) Scalar
 
-	// Clone creates a new Scalar with same value
+	// Clone creates a new Scalar with the same value.
 	Clone() Scalar
 
-	// Set sets the receiver to a small integer value
+	// SetInt64 sets the receiver to a small integer value.
 	SetInt64(v int64) Scalar
 
-	// Set to the additive identity (0)
+	// Set to the additive identity (0).
 	Zero() Scalar
 
-	// Set to the modular sum of scalars a and b
+	// Set to the modular sum of scalars a and b.
 	Add(a, b Scalar) Scalar
 
-	// Set to the modular difference a - b
+	// Set to the modular difference a - b.
 	Sub(a, b Scalar) Scalar
 
-	// Set to the modular negation of scalar a
+	// Set to the modular negation of scalar a.
 	Neg(a Scalar) Scalar
 
-	// Set to the multiplicative identity (1)
+	// Set to the multiplicative identity (1).
 	One() Scalar
 
-	// Set to the modular product of scalars a and b
+	// Set to the modular product of scalars a and b.
 	Mul(a, b Scalar) Scalar
 
-	// Set to the modular division of scalar a by scalar b
+	// Set to the modular division of scalar a by scalar b.
 	Div(a, b Scalar) Scalar
 
-	// Set to the modular inverse of scalar a
+	// Set to the modular inverse of scalar a.
 	Inv(a Scalar) Scalar
 
-	// Set to a fresh random or pseudo-random scalar
+	// Set to a fresh random or pseudo-random scalar.
 	Pick(rand cipher.Stream) Scalar
 
 	// SetBytes sets the scalar from a byte-slice,
@@ -58,7 +58,7 @@ type Scalar interface {
 	SetBytes([]byte) Scalar
 }
 
-// A Point kyber.y represents an element of a public-key cryptographic Group.
+// Point represents an element of a public-key cryptographic Group.
 // For example,
 // this is a number modulo the prime P in a DSA-style Schnorr group,
 // or an (x, y) point on an elliptic curve.
@@ -66,13 +66,13 @@ type Scalar interface {
 type Point interface {
 	Marshaling
 
-	// Equality test for two Points derived from the same Group
+	// Equality test for two Points derived from the same Group.
 	Equal(s2 Point) bool
 
 	// Null sets the receiver to the neutral identity element.
 	Null() Point
 
-	// Set sets the receiver to this group's standard base point.
+	// Base sets the receiver to this group's standard base point.
 	Base() Point
 
 	// Pick sets the receiver to a fresh random or pseudo-random Point.
@@ -98,13 +98,13 @@ type Point interface {
 	// Returns an error if doesn't represent valid embedded data.
 	Data() ([]byte, error)
 
-	// Add points so that their scalars add homomorphically
+	// Add points so that their scalars add homomorphically.
 	Add(a, b Point) Point
 
-	// Subtract points so that their scalars subtract homomorphically
+	// Subtract points so that their scalars subtract homomorphically.
 	Sub(a, b Point) Point
 
-	// Set to the negation of point a
+	// Set to the negation of point a.
 	Neg(a Point) Point
 
 	// Multiply point p by the scalar s.


### PR DESCRIPTION
Fix documentation typos in the Scalar and Point interface. Add full stop
to the Scalar interface documentation to be consistent with the Point
documentation.