### PR TITLE
Fix vss marshaling to work with fixed protobuf encoder

### DIFF
--- a/share/dkg/rabin/dkg.go
+++ b/share/dkg/rabin/dkg.go
@@ -43,6 +43,7 @@ import (
 
 	"github.com/dedis/kyber"
 	"github.com/dedis/kyber/sign/schnorr"
+	"github.com/dedis/protobuf"
 
 	"github.com/dedis/kyber/share"
 	vss "github.com/dedis/kyber/share/vss/rabin"
@@ -671,7 +672,7 @@ func (cc *ComplaintCommits) Hash(s Suite) []byte {
 	_, _ = h.Write([]byte("commitcomplaint"))
 	_ = binary.Write(h, binary.LittleEndian, cc.Index)
 	_ = binary.Write(h, binary.LittleEndian, cc.DealerIndex)
-	buff, _ := cc.Deal.MarshalBinary()
+	buff, _ := protobuf.Encode(cc.Deal)
 	_, _ = h.Write(buff)
 	return h.Sum(nil)
 }

--- a/share/vss/pedersen/vss.go
+++ b/share/vss/pedersen/vss.go
@@ -197,7 +197,7 @@ func (d *Dealer) EncryptedDeal(i int) (*EncryptedDeal, error) {
 	}
 
 	nonce := make([]byte, gcm.NonceSize())
-	dealBuff, err := d.deals[i].MarshalBinary()
+	dealBuff, err := protobuf.Encode(d.deals[i])
 	if err != nil {
 		return nil, err
 	}
@@ -418,7 +418,7 @@ func (v *Verifier) decryptDeal(e *EncryptedDeal) (*Deal, error) {
 		return nil, err
 	}
 	deal := &Deal{}
-	err = deal.UnmarshalBinary(v.suite, decrypted)
+	err = deal.decode(v.suite, decrypted)
 	return deal, err
 }
 
@@ -730,14 +730,8 @@ func (r *Response) Hash(s Suite) []byte {
 	return h.Sum(nil)
 }
 
-// MarshalBinary returns the binary representations of a Deal.
-// The encryption of a deal operates on this binary representation.
-func (d *Deal) MarshalBinary() ([]byte, error) {
-	return protobuf.Encode(d)
-}
-
 // UnmarshalBinary reads the Deal from the binary represenstation.
-func (d *Deal) UnmarshalBinary(s Suite, buff []byte) error {
+func (d *Deal) decode(s Suite, buff []byte) error {
 	constructors := make(protobuf.Constructors)
 	var point kyber.Point
 	var secret kyber.Scalar
@@ -752,7 +746,7 @@ func (j *Justification) Hash(s Suite) []byte {
 	_, _ = h.Write([]byte("justification"))
 	_, _ = h.Write(j.SessionID)
 	_ = binary.Write(h, binary.LittleEndian, j.Index)
-	buff, _ := j.Deal.MarshalBinary()
+	buff, _ := protobuf.Encode(j.Deal)
 	_, _ = h.Write(buff)
 	return h.Sum(nil)
 }

--- a/share/vss/pedersen/vss_test.go
+++ b/share/vss/pedersen/vss_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/dedis/kyber/group/edwards25519"
 	"github.com/dedis/kyber/sign/schnorr"
 	"github.com/dedis/kyber/xof/blake2xb"
+	"github.com/dedis/protobuf"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -205,8 +206,8 @@ func TestVSSVerifierDecryptDeal(t *testing.T) {
 	require.Nil(t, err)
 	decD, err := v.decryptDeal(encD)
 	require.Nil(t, err)
-	b1, _ := d.MarshalBinary()
-	b2, _ := decD.MarshalBinary()
+	b1, _ := protobuf.Encode(d)
+	b2, _ := protobuf.Encode(decD)
 	assert.Equal(t, b1, b2)
 
 	// wrong dh key

--- a/share/vss/rabin/vss.go
+++ b/share/vss/rabin/vss.go
@@ -222,7 +222,7 @@ func (d *Dealer) EncryptedDeal(i int) (*EncryptedDeal, error) {
 	}
 
 	nonce := make([]byte, gcm.NonceSize())
-	dealBuff, err := d.deals[i].MarshalBinary()
+	dealBuff, err := protobuf.Encode(d.deals[i])
 	if err != nil {
 		return nil, err
 	}
@@ -435,7 +435,7 @@ func (v *Verifier) decryptDeal(e *EncryptedDeal) (*Deal, error) {
 		return nil, err
 	}
 	deal := &Deal{}
-	err = deal.UnmarshalBinary(v.suite, decrypted)
+	err = deal.decode(v.suite, decrypted)
 	return deal, err
 }
 
@@ -744,14 +744,7 @@ func (r *Response) Hash(s Suite) []byte {
 	return h.Sum(nil)
 }
 
-// MarshalBinary returns the binary representations of a Deal.
-// The encryption of a deal operates on this binary representation.
-func (d *Deal) MarshalBinary() ([]byte, error) {
-	return protobuf.Encode(d)
-}
-
-// UnmarshalBinary reads the Deal from the binary represenstation.
-func (d *Deal) UnmarshalBinary(s Suite, buff []byte) error {
+func (d *Deal) decode(s Suite, buff []byte) error {
 	constructors := make(protobuf.Constructors)
 	var point kyber.Point
 	var secret kyber.Scalar
@@ -766,7 +759,7 @@ func (j *Justification) Hash(s Suite) []byte {
 	_, _ = h.Write([]byte("justification"))
 	_, _ = h.Write(j.SessionID)
 	_ = binary.Write(h, binary.LittleEndian, j.Index)
-	buff, _ := j.Deal.MarshalBinary()
+	buff, _ := protobuf.Encode(j.Deal)
 	_, _ = h.Write(buff)
 	return h.Sum(nil)
 }

--- a/share/vss/rabin/vss_test.go
+++ b/share/vss/rabin/vss_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/dedis/kyber"
 	"github.com/dedis/kyber/group/edwards25519"
 	"github.com/dedis/kyber/sign/schnorr"
+	"github.com/dedis/protobuf"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -187,8 +188,8 @@ func TestVSSVerifierDecryptDeal(t *testing.T) {
 	require.Nil(t, err)
 	decD, err := v.decryptDeal(encD)
 	require.Nil(t, err)
-	b1, _ := d.MarshalBinary()
-	b2, _ := decD.MarshalBinary()
+	b1, _ := protobuf.Encode(d)
+	b2, _ := protobuf.Encode(decD)
 	assert.Equal(t, b1, b2)
 
 	// wrong dh key


### PR DESCRIPTION
Before the BinaryMarshaler detection was not working. When
we fixed the BinaryMarashaler detection, it turned out this
code had always been wrong (recursive loop) but never called.
Now we use the simplest thing possible: protobuf.Encode for
encoding, and the previous code for decoding (but not triggering
the BinaryUnmarshaler detection).