### PR TITLE
A mechanism for callers to opt-in to a limit on suites

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,11 +11,16 @@ Please see the
 [Godoc documentation for this package](http://godoc.org/github.com/dedis/kyber)
 for details on the library's purpose and API functionality.
 
+This package includes a mix of variable time and constant time
+implementations. If your application is sensitive to timing-based attacks
+and you need to constrain Kyber to offering only constant time implementations,
+you should use the [suites.RequireConstantTime()](https://godoc.org/github.com/dedis/kyber/suites#RequireConstantTime)
+function in the `init()` function of your `main` package.
+
 Versioning - Development
 ------------------------
 
-With the new interface in the kyber-library we use the following development
-model:
+We use the following versioning model:
 
 * crypto.v0 was the previous semi-stable version. See
   [migration notes](https://github.com/dedis/kyber/wiki/Migration-from-gopkg.in-dedis-crypto.v0).

--- a/suites/suites.go
+++ b/suites/suites.go
@@ -22,6 +22,8 @@ type Suite interface {
 
 var suites = map[string]Suite{}
 
+var requireConstTime = false
+
 // register is called by suites to make themselves known to Kyber.
 //
 func register(s Suite) {
@@ -35,6 +37,9 @@ var ErrUnknownSuite = errors.New("unknown suite")
 // Find looks up a suite by name.
 func Find(name string) (Suite, error) {
 	if s, ok := suites[strings.ToLower(name)]; ok {
+		if requireConstTime && strings.ToLower(s.String()) != "ed25519" {
+			return nil, errors.New("requested suite exists but is not implemented with constant time algorithms as required by suites.RequireConstantTime")
+		}
 		return s, nil
 	}
 	return nil, ErrUnknownSuite
@@ -47,4 +52,16 @@ func MustFind(name string) Suite {
 		panic("Suite " + name + " not found.")
 	}
 	return s
+}
+
+// RequireConstantTime causes all future calls to Find and MustFind to only
+// search for suites where the implementation is constant time.
+// It should be called in an init() function for the main package
+// of users of Kyber who need to be sure to avoid variable time implementations.
+// Once constant time implementations are required, there is no way to
+// turn it back off (by design).
+//
+// At this time, the only constant time crypto suite is "Ed25519".
+func RequireConstantTime() {
+	requireConstTime = true
 }

--- a/suites/suites_test.go
+++ b/suites/suites_test.go
@@ -6,7 +6,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func Test_Find(t *testing.T) {
+func TestSuites_Find(t *testing.T) {
 	ss := []string{
 		"ed25519",
 		"bn256.G1",
@@ -26,7 +26,7 @@ func Test_Find(t *testing.T) {
 	}
 }
 
-func Test_ConstTime(t *testing.T) {
+func TestSuites_ConstTime(t *testing.T) {
 	RequireConstantTime()
 	defer func() { requireConstTime = false }()
 

--- a/suites/suites_test.go
+++ b/suites/suites_test.go
@@ -6,7 +6,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestSuites_Find(t *testing.T) {
+func Test_Find(t *testing.T) {
 	ss := []string{
 		"ed25519",
 		"bn256.G1",
@@ -24,4 +24,17 @@ func TestSuites_Find(t *testing.T) {
 		s = MustFind(name)
 		require.NotNil(t, s, "missing "+name)
 	}
+}
+
+func Test_ConstTime(t *testing.T) {
+	RequireConstantTime()
+	defer func() { requireConstTime = false }()
+
+	s, err := Find("bn256.G1")
+	require.Error(t, err)
+	require.Nil(t, s)
+
+	s, err = Find("ed25519")
+	require.NoError(t, err)
+	require.NotNil(t, s)
 }


### PR DESCRIPTION
Previously, vartime suites were not even compiled in. We found this to
be difficult to work with when we need to mix vartime and constant
time algorithms (i.e. in Cothority). This is a compromise: by having
callers add one line to their init() function in package main,
they can opt-in to a different implementation that still provides
the same safety as the old implementation.