### PR TITLE
batch verification of BLS signature/msg pairs

### DIFF
--- a/sign/bls/bls_test.go
+++ b/sign/bls/bls_test.go
@@ -1,8 +1,10 @@
 package bls
 
 import (
+	"crypto/rand"
 	"testing"
 
+	"github.com/dedis/kyber"
 	"github.com/dedis/kyber/pairing/bn256"
 	"github.com/dedis/kyber/util/random"
 	"github.com/stretchr/testify/require"
@@ -96,6 +98,55 @@ func TestBLSFailAggregatedKey(t *testing.T) {
 		t.Fatal("bls: verification succeeded unexpectedly")
 	}
 }
+func TestBLSBatchVerify(t *testing.T) {
+	msg1 := []byte("Hello Boneh-Lynn-Shacham")
+	msg2 := []byte("Hello Dedis & Boneh-Lynn-Shacham")
+	suite := bn256.NewSuite()
+	private1, public1 := NewKeyPair(suite, random.New())
+	private2, public2 := NewKeyPair(suite, random.New())
+	sig1, err := Sign(suite, private1, msg1)
+	require.Nil(t, err)
+	sig2, err := Sign(suite, private2, msg2)
+	require.Nil(t, err)
+	aggregatedSig, err := AggregateSignatures(suite, sig1, sig2)
+	require.Nil(t, err)
+
+	err = BatchVerify(suite, []kyber.Point{public1, public2}, [][]byte{msg1, msg2}, aggregatedSig)
+	require.Nil(t, err)
+}
+func TestBLSFailBatchVerify(t *testing.T) {
+	msg1 := []byte("Hello Boneh-Lynn-Shacham")
+	msg2 := []byte("Hello Dedis & Boneh-Lynn-Shacham")
+	suite := bn256.NewSuite()
+	private1, public1 := NewKeyPair(suite, random.New())
+	private2, public2 := NewKeyPair(suite, random.New())
+	sig1, err := Sign(suite, private1, msg1)
+	require.Nil(t, err)
+	sig2, err := Sign(suite, private2, msg2)
+	require.Nil(t, err)
+
+	t.Run("fails with a bad signature", func(t *testing.T) {
+		aggregatedSig, err := AggregateSignatures(suite, sig1, sig2)
+		require.Nil(t, err)
+		msg2[0] ^= 0x01
+		if BatchVerify(suite, []kyber.Point{public1, public2}, [][]byte{msg1, msg2}, aggregatedSig) == nil {
+			t.Fatal("bls: verification succeeded unexpectedly")
+		}
+	})
+
+	t.Run("fails with a duplicate msg", func(t *testing.T) {
+		private3, public3 := NewKeyPair(suite, random.New())
+		sig3, err := Sign(suite, private3, msg1)
+		require.Nil(t, err)
+		aggregatedSig, err := AggregateSignatures(suite, sig1, sig2, sig3)
+		require.Nil(t, err)
+
+		if BatchVerify(suite, []kyber.Point{public1, public2, public3}, [][]byte{msg1, msg2, msg1}, aggregatedSig) == nil {
+			t.Fatal("bls: verification succeeded unexpectedly")
+		}
+	})
+
+}
 
 func BenchmarkBLSKeyCreation(b *testing.B) {
 	suite := bn256.NewSuite()
@@ -145,5 +196,32 @@ func BenchmarkBLSVerifyAggregate(b *testing.B) {
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		Verify(suite, key, msg, sig)
+	}
+}
+
+func BenchmarkBLSVerifyBatchVerify(b *testing.B) {
+	suite := bn256.NewSuite()
+
+	numSigs := 100
+	privates := make([]kyber.Scalar, numSigs)
+	publics := make([]kyber.Point, numSigs)
+	msgs := make([][]byte, numSigs)
+	sigs := make([][]byte, numSigs)
+	for i := 0; i < numSigs; i++ {
+		private, public := NewKeyPair(suite, random.New())
+		privates[i] = private
+		publics[i] = public
+		msg := make([]byte, 64, 64)
+		rand.Read(msg)
+		msgs[i] = msg
+		sig, err := Sign(suite, private, msg)
+		require.Nil(b, err)
+		sigs[i] = sig
+	}
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		aggregateSig, _ := AggregateSignatures(suite, sigs...)
+		BatchVerify(suite, publics, msgs, aggregateSig)
 	}
 }


### PR DESCRIPTION
This adds batch verification of a number of signatures where the messages are distinct. Generally this is just used for a performance enhancement. The benchmarks show that the verification is time for the 100 sigs here takes roughly the same amount as 50 signature verifications individually.