### PR TITLE
Change MarshalID from bn256.pt to bn256.g2

### DIFF
--- a/pairing/bn256/point.go
+++ b/pairing/bn256/point.go
@@ -10,7 +10,7 @@ import (
 	"github.com/dedis/kyber/group/mod"
 )
 
-var marshalPointID = [8]byte{'b', 'n', '2', '5', '6', '.', 'p', 't'}
+var marshalPointID = [8]byte{'b', 'n', '2', '5', '6', '.', 'g', '2'}
 
 type pointG1 struct {
 	g *curvePoint

--- a/pairing/bn256/suite_test.go
+++ b/pairing/bn256/suite_test.go
@@ -115,7 +115,7 @@ func TestG2(t *testing.T) {
 	k := suite.G2().Scalar().Pick(random.New())
 	require.Equal(t, "mod.int ", fmt.Sprintf("%s", k.(*mod.Int).MarshalID()))
 	pa := suite.G2().Point().Mul(k, nil)
-	require.Equal(t, "bn256.pt", fmt.Sprintf("%s", pa.(*pointG2).MarshalID()))
+	require.Equal(t, "bn256.g2", fmt.Sprintf("%s", pa.(*pointG2).MarshalID()))
 	ma, err := pa.MarshalBinary()
 	require.Nil(t, err)
 	pb := new(bn256.G2).ScalarBaseMult(&k.(*mod.Int).V)


### PR DESCRIPTION
This is done so that it is consistent if we need to also give G1 a
MarshalID (bn256.g1).