### PR TITLE
Properly marshal/unmarshal zero G2 points

### DIFF
--- a/pairing/bn256/point.go
+++ b/pairing/bn256/point.go
@@ -1,6 +1,7 @@
 package bn256
 
 import (
+	"bytes"
 	"crypto/cipher"
 	"crypto/subtle"
 	"errors"
@@ -282,6 +283,9 @@ func (p *pointG2) MarshalBinary() ([]byte, error) {
 	}
 
 	p.g.MakeAffine()
+	if p.g.IsInfinity() {
+		return make([]byte, p.MarshalSize()), nil
+	}
 
 	ret := make([]byte, p.MarshalSize())
 	temp := &gfP{}
@@ -318,6 +322,12 @@ func (p *pointG2) UnmarshalBinary(buf []byte) error {
 
 	if len(buf) < p.MarshalSize() {
 		return errors.New("bn256.G2: not enough data")
+	}
+
+	zeros := make([]byte, p.MarshalSize())
+	if bytes.Equal(buf, zeros) {
+		p.g.SetInfinity()
+		return nil
 	}
 
 	p.g.x.x.Unmarshal(buf[0*n:])

--- a/pairing/bn256/suite_test.go
+++ b/pairing/bn256/suite_test.go
@@ -137,6 +137,19 @@ func TestG2Marshal(t *testing.T) {
 	require.Equal(t, ma, mb)
 }
 
+func TestG2MarshalZero(t *testing.T) {
+	suite := NewSuite()
+	pa := suite.G2().Point()
+	ma, err := pa.MarshalBinary()
+	require.Nil(t, err)
+	pb := suite.G2().Point()
+	err = pb.UnmarshalBinary(ma)
+	require.Nil(t, err)
+	mb, err := pb.MarshalBinary()
+	require.Nil(t, err)
+	require.Equal(t, ma, mb)
+}
+
 func TestG2Ops(t *testing.T) {
 	suite := NewSuite()
 	a := suite.G2().Point().Pick(random.New())


### PR DESCRIPTION
After commit 09d88ea559cff, a round-trip encode/decode
of a zero point was failing. TestG2Marshal would have
discovered this 1 time in 2^256 runs, but in order to speed
up testing, add a new TestG2MarshalZero which always fails.

The solution is to follow the previous code patch from where a zero point
was detected, i.e. run p.g.SetInfinity(). This is still compatible
with golang.org/x/crypto/bn256, which also marshals infinity
as all zeros. (Checked this via printf-debugging on it.)