### PR TITLE
Fix import path of fixbuf

### DIFF
--- a/group/curve25519/suite.go
+++ b/group/curve25519/suite.go
@@ -7,11 +7,11 @@ import (
 	"io"
 	"reflect"
 
-	"github.com/dedis/fixbuf"
 	"github.com/dedis/kyber"
 	"github.com/dedis/kyber/group/internal/marshalling"
 	"github.com/dedis/kyber/util/random"
 	"github.com/dedis/kyber/xof/blake2xb"
+	"go.dedis.ch/fixbuf"
 )
 
 // SuiteCurve25519 is the suite for the 25519 curve

--- a/group/edwards25519/suite.go
+++ b/group/edwards25519/suite.go
@@ -7,11 +7,11 @@ import (
 	"io"
 	"reflect"
 
-	"github.com/dedis/fixbuf"
 	"github.com/dedis/kyber"
 	"github.com/dedis/kyber/group/internal/marshalling"
 	"github.com/dedis/kyber/util/random"
 	"github.com/dedis/kyber/xof/blake2xb"
+	"go.dedis.ch/fixbuf"
 )
 
 // SuiteEd25519 implements some basic functionalities such as Group, HashFactory,

--- a/group/nist/qrsuite.go
+++ b/group/nist/qrsuite.go
@@ -8,11 +8,11 @@ import (
 	"math/big"
 	"reflect"
 
-	"github.com/dedis/fixbuf"
 	"github.com/dedis/kyber"
 	"github.com/dedis/kyber/group/internal/marshalling"
 	"github.com/dedis/kyber/util/random"
 	"github.com/dedis/kyber/xof/blake2xb"
+	"go.dedis.ch/fixbuf"
 )
 
 // QrSuite is a quadratic residue suite

--- a/group/nist/suite.go
+++ b/group/nist/suite.go
@@ -7,11 +7,11 @@ import (
 	"io"
 	"reflect"
 
-	"github.com/dedis/fixbuf"
 	"github.com/dedis/kyber"
 	"github.com/dedis/kyber/group/internal/marshalling"
 	"github.com/dedis/kyber/util/random"
 	"github.com/dedis/kyber/xof/blake2xb"
+	"go.dedis.ch/fixbuf"
 )
 
 // Suite128 is the suite for P256 curve

--- a/pairing/bn256/suite.go
+++ b/pairing/bn256/suite.go
@@ -7,10 +7,10 @@ import (
 	"io"
 	"reflect"
 
-	"github.com/dedis/fixbuf"
 	"github.com/dedis/kyber"
 	"github.com/dedis/kyber/util/random"
 	"github.com/dedis/kyber/xof/blake2xb"
+	"go.dedis.ch/fixbuf"
 )
 
 // Suite implements the pairing.Suite interface for the BN256 bilinear pairing.


### PR DESCRIPTION
I was debugging tests that only fail on travis and suddenly it stopped building due to a change in import path of fixbuf. This PR fixes the issue.