### PR TITLE
Remove test command as it does not have any usage #337

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,10 +43,6 @@ as follows:
 
 	go get go.dedis.ch/kyber
 
-You should then be able to test its basic function as follows:
-
-	go test -v
-
 You can recursively test all the packages in the library as follows:
 
 	go test -v ./...


### PR DESCRIPTION
This removes an instruction that does not work, as there are no test on the main part, as defined in issue #337 .