### PR TITLE
Fix suite.Read

### DIFF
--- a/pairing/bn256/suite.go
+++ b/pairing/bn256/suite.go
@@ -105,9 +105,11 @@ type commonSuite struct {
 func (c *commonSuite) New(t reflect.Type) interface{} {
 	switch t {
 	case tScalar:
-		return c.Scalar()
+		g2 := groupG2{}
+		return g2.Scalar()
 	case tPoint:
-		return c.Point()
+		g2 := groupG2{}
+		return g2.Point()
 	case tPointG1:
 		g1 := groupG1{}
 		return g1.Point()

--- a/pairing/bn256/suite_test.go
+++ b/pairing/bn256/suite_test.go
@@ -1,7 +1,9 @@
 package bn256
 
 import (
+	"bytes"
 	"fmt"
+	"go.dedis.ch/kyber/v3"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -269,4 +271,18 @@ func basicPointTest(t *testing.T, s *Suite) {
 	pb1 := s.Point().Mul(b, nil)
 	pb2 := s.Point().Add(pa, s.Point().Base())
 	require.True(t, pb1.Equal(pb2))
+}
+
+// Test that the suite.Read works correctly.
+func TestSuiteRead(t *testing.T) {
+	suite := NewSuite()
+	pOrig := suite.G2().Point().Base()
+	var pBuf bytes.Buffer
+	err := suite.Write(&pBuf, pOrig)
+	require.Nil(t, err)
+
+	var pCopy kyber.Point
+	err = suite.Read(&pBuf, &pCopy)
+	require.Nil(t, err)
+	require.True(t, pCopy.Equal(pOrig))
 }


### PR DESCRIPTION
The current suite.New doesn't correctly initialize the Scalar and Point
interfaces. This PR fixes it and returns the correct Point and Scalar.

Another possibility would be to actually implement Point and Scalar directly
on the bn256.Suite, which is currently not done.

Yet another possibility is to remove the `tScalar` and `tPoint` from `New`, and move those to `pairing.NewSuiteBn256`.