### PR TITLE
Correct implementation of commonSuite

### DIFF
--- a/pairing/bn256/point.go
+++ b/pairing/bn256/point.go
@@ -12,7 +12,9 @@ import (
 	"go.dedis.ch/kyber/v3/group/mod"
 )
 
-var marshalPointID = [8]byte{'b', 'n', '2', '5', '6', '.', 'g', '2'}
+var marshalPointID1 = [8]byte{'b', 'n', '2', '5', '6', '.', 'g', '1'}
+var marshalPointID2 = [8]byte{'b', 'n', '2', '5', '6', '.', 'g', '2'}
+var marshalPointIDT = [8]byte{'b', 'n', '2', '5', '6', '.', 'g', 't'}
 
 type pointG1 struct {
 	g *curvePoint
@@ -124,6 +126,10 @@ func (p *pointG1) MarshalBinary() ([]byte, error) {
 	montDecode(tmp, &pgtemp.y)
 	tmp.Marshal(ret[n:])
 	return ret, nil
+}
+
+func (p *pointG1) MarshalID() [8]byte {
+	return marshalPointID1
 }
 
 func (p *pointG1) MarshalTo(w io.Writer) (int, error) {
@@ -362,7 +368,7 @@ func (p *pointG2) MarshalBinary() ([]byte, error) {
 }
 
 func (p *pointG2) MarshalID() [8]byte {
-	return marshalPointID
+	return marshalPointID2
 }
 
 func (p *pointG2) MarshalTo(w io.Writer) (int, error) {
@@ -545,6 +551,10 @@ func (p *pointGT) MarshalBinary() ([]byte, error) {
 	temp.Marshal(ret[11*n:])
 
 	return ret, nil
+}
+
+func (p *pointGT) MarshalID() [8]byte {
+	return marshalPointIDT
 }
 
 func (p *pointGT) MarshalTo(w io.Writer) (int, error) {

--- a/pairing/bn256/suite.go
+++ b/pairing/bn256/suite.go
@@ -103,13 +103,14 @@ type commonSuite struct {
 
 // New implements the kyber.Encoding interface.
 func (c *commonSuite) New(t reflect.Type) interface{} {
+	if c.Group == nil {
+		panic("cannot create Point from NewGroup - please use bn256.NewGroupG1")
+	}
 	switch t {
 	case tScalar:
-		g2 := groupG2{}
-		return g2.Scalar()
+		return c.Scalar()
 	case tPoint:
-		g2 := groupG2{}
-		return g2.Point()
+		return c.Point()
 	case tPointG1:
 		g1 := groupG1{}
 		return g1.Point()


### PR DESCRIPTION
After my last try I understand better what is needed to implement the
`commonSuite` in a convenient way. This PR reverts the previous patch
and makes it so that a `bn256.NewSuite` cannot be used for `New` or `Read`
on a `Point` or `Scalar`. Only `bn256.NewSuiteG[12G]` can do so.

It also makes `NewSuiteG[1T]` a correct InterfaceMarshaler.