### PR TITLE
Rename the asms package to bdn

### DIFF
--- a/sign/bdn/bdn.go
+++ b/sign/bdn/bdn.go
@@ -1,11 +1,13 @@
-// Package asmbls implements the Accountable-Subgroup Multi-BLS scheme which is
+// Package bdn implements the Boneh-Drijvers-Neven signature scheme which is
 // an implementation of the bls package which is robust against rogue public-key attacks. Those
 // attacks could allow an attacker to forge a public-key and then make a verifiable
 // signature for an aggregation of signatures. It fixes the situation by
 // adding coefficients to the aggregate.
 //
-// See the paper: https://crypto.stanford.edu/~dabo/pubs/papers/BLSmultisig.html
-package asmbls
+// See the papers:
+// https://eprint.iacr.org/2018/483.pdf
+// https://crypto.stanford.edu/~dabo/pubs/papers/BLSmultisig.html
+package bdn
 
 import (
 	"crypto/cipher"

--- a/sign/bdn/bdn_test.go
+++ b/sign/bdn/bdn_test.go
@@ -1,4 +1,4 @@
-package asmbls
+package bdn
 
 import (
 	"testing"
@@ -17,7 +17,7 @@ var two = suite.Scalar().Add(suite.Scalar().One(), suite.Scalar().One())
 var three = suite.Scalar().Add(two, suite.Scalar().One())
 
 // Reference test for other languages
-func TestBLS2_HashPointToR_BN256(t *testing.T) {
+func TestBDN_HashPointToR_BN256(t *testing.T) {
 	p1 := suite.Point().Base()
 	p2 := suite.Point().Mul(two, suite.Point().Base())
 	p3 := suite.Point().Mul(three, suite.Point().Base())
@@ -31,7 +31,7 @@ func TestBLS2_HashPointToR_BN256(t *testing.T) {
 	require.Equal(t, 16, coefs[0].MarshalSize())
 }
 
-func TestBLS2_AggregateSignatures(t *testing.T) {
+func TestBDN_AggregateSignatures(t *testing.T) {
 	msg := []byte("Hello Boneh-Lynn-Shacham")
 	suite := bn256.NewSuite()
 	private1, public1 := NewKeyPair(suite, random.New())
@@ -66,7 +66,7 @@ func TestBLS2_AggregateSignatures(t *testing.T) {
 	require.Error(t, err)
 }
 
-func TestBLS2_SubsetSignature(t *testing.T) {
+func TestBDN_SubsetSignature(t *testing.T) {
 	msg := []byte("Hello Boneh-Lynn-Shacham")
 	suite := bn256.NewSuite()
 	private1, public1 := NewKeyPair(suite, random.New())
@@ -93,7 +93,7 @@ func TestBLS2_SubsetSignature(t *testing.T) {
 	require.NoError(t, err)
 }
 
-func TestBLS2_RogueAttack(t *testing.T) {
+func TestBDN_RogueAttack(t *testing.T) {
 	msg := []byte("Hello Boneh-Lynn-Shacham")
 	suite := bn256.NewSuite()
 	// honest
@@ -122,7 +122,7 @@ func TestBLS2_RogueAttack(t *testing.T) {
 	require.Error(t, Verify(suite, agg, msg, sig))
 }
 
-func Benchmark_BLS2_AggregateSigs(b *testing.B) {
+func Benchmark_BDN_AggregateSigs(b *testing.B) {
 	suite := bn256.NewSuite()
 	private1, public1 := NewKeyPair(suite, random.New())
 	private2, public2 := NewKeyPair(suite, random.New())

--- a/sign/bls/bls.go
+++ b/sign/bls/bls.go
@@ -5,7 +5,7 @@
 // Deprecated: This version is vulnerable to rogue public-key attack and the
 // new version of the protocol should be used to make sure a signature
 // aggregate cannot be verified by a forged key. You can find the protocol
-// in kyber/sign/asmbls. Note that only the aggregation is broken against the
+// in kyber/sign/bdn. Note that only the aggregation is broken against the
 // attack and a later version will merge bls and asmbls.
 //
 // See the paper: https://crypto.stanford.edu/~dabo/pubs/papers/BLSmultisig.html


### PR DESCRIPTION
Author names are used instead of ASM because we're only using a better
version of the BLS scheme but not really the ASMS scheme so we rename it
to avoid future confusion.