### PR TITLE
Copy the policies to kyber/sign

### DIFF
--- a/sign/cosi/cosi.go
+++ b/sign/cosi/cosi.go
@@ -380,12 +380,16 @@ func AggregateMasks(a, b []byte) ([]byte, error) {
 // use any other relevant contextual information (e.g., how security-critical
 // the operation relying on the collective signature is) in determining whether
 // the collective signature was produced by an acceptable set of cosigners.
+//
+// Deprecated: the policies have moved to the package kyber/sign
 type Policy interface {
 	Check(m ParticipationMask) bool
 }
 
 // CompletePolicy is the default policy requiring that all participants have
 // cosigned to make a collective signature valid.
+//
+// Deprecated: the policy has moved to the package kyber/sign
 type CompletePolicy struct {
 }
 
@@ -398,11 +402,15 @@ func (p CompletePolicy) Check(m ParticipationMask) bool {
 // ThresholdPolicy allows to specify a simple t-of-n policy requring that at
 // least the given threshold number of participants t have cosigned to make a
 // collective signature valid.
+//
+// Deprecated: the policy has moved to the package kyber/sign
 type ThresholdPolicy struct {
 	thold int
 }
 
 // NewThresholdPolicy returns a new ThresholdPolicy with the given threshold.
+//
+// Deprecated: the policy has moved to the package kyber/sign
 func NewThresholdPolicy(thold int) *ThresholdPolicy {
 	return &ThresholdPolicy{thold: thold}
 }

--- a/sign/policy.go
+++ b/sign/policy.go
@@ -1,0 +1,50 @@
+package sign
+
+// ParticipationMask is an interface to get the total number of candidates
+// and the number of participants.
+type ParticipationMask interface {
+	// CountEnabled returns the number of participants
+	CountEnabled() int
+	// CountTotal returns the number of candidates
+	CountTotal() int
+}
+
+// Policy represents a fully customizable cosigning policy deciding what
+// cosigner sets are and aren't sufficient for a collective signature to be
+// considered acceptable to a verifier. The Check method may inspect the set of
+// participants that cosigned by invoking cosi.Mask and/or cosi.MaskBit, and may
+// use any other relevant contextual information (e.g., how security-critical
+// the operation relying on the collective signature is) in determining whether
+// the collective signature was produced by an acceptable set of cosigners.
+type Policy interface {
+	Check(m ParticipationMask) bool
+}
+
+// CompletePolicy is the default policy requiring that all participants have
+// cosigned to make a collective signature valid.
+type CompletePolicy struct {
+}
+
+// Check verifies that all participants have contributed to a collective
+// signature.
+func (p CompletePolicy) Check(m ParticipationMask) bool {
+	return m.CountEnabled() == m.CountTotal()
+}
+
+// ThresholdPolicy allows to specify a simple t-of-n policy requring that at
+// least the given threshold number of participants t have cosigned to make a
+// collective signature valid.
+type ThresholdPolicy struct {
+	thold int
+}
+
+// NewThresholdPolicy returns a new ThresholdPolicy with the given threshold.
+func NewThresholdPolicy(thold int) *ThresholdPolicy {
+	return &ThresholdPolicy{thold: thold}
+}
+
+// Check verifies that at least a threshold number of participants have
+// contributed to a collective signature.
+func (p ThresholdPolicy) Check(m ParticipationMask) bool {
+	return m.CountEnabled() >= p.thold
+}

--- a/sign/policy_test.go
+++ b/sign/policy_test.go
@@ -1,0 +1,46 @@
+package sign
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+type testMask struct {
+	numCandidates   int
+	numParticipants int
+}
+
+func (m testMask) CountTotal() int {
+	return m.numCandidates
+}
+
+func (m testMask) CountEnabled() int {
+	return m.numParticipants
+}
+
+func TestPolicy_CompletePolicy(t *testing.T) {
+	mask := testMask{
+		numCandidates:   4,
+		numParticipants: 4,
+	}
+
+	policy := CompletePolicy{}
+	require.True(t, policy.Check(mask))
+
+	mask.numParticipants = 3
+	require.False(t, policy.Check(mask))
+}
+
+func TestPolicy_ThresholdPolicy(t *testing.T) {
+	mask := testMask{
+		numCandidates:   5,
+		numParticipants: 2,
+	}
+
+	policy := NewThresholdPolicy(3)
+	require.False(t, policy.Check(mask))
+
+	mask.numParticipants = 3
+	require.True(t, policy.Check(mask))
+}


### PR DESCRIPTION
This PR copies the implementation of the policies to the same package as the mask ones to optimize the dependencies as those two are often used in parallel. It also adds a few tests as they were none.