### PR TITLE
Fix multiplication for bn256 arm64

### DIFF
--- a/pairing/bn256/mul_arm64.h
+++ b/pairing/bn256/mul_arm64.h
@@ -60,7 +60,7 @@
 	ADCS R0, R29 \
 	UMULH R4, R8, c7 \
 	ADCS ZR, c7 \
-	ADDS R25, c3 \
+	ADDS R1, c3 \
 	ADCS R26, c4 \
 	ADCS R27, c5 \
 	ADCS R29, c6 \


### PR DESCRIPTION
This pull requests fixes a problem with multiplication on arm64 that is causing a **bn256.G2: malformed point** when running it on a raspberry pi4 with a build for arm64. 