### PR TITLE
DKG uses the new random stream structure

### DIFF
--- a/share/dkg/pedersen/dkg.go
+++ b/share/dkg/pedersen/dkg.go
@@ -83,7 +83,10 @@ type Config struct {
 	// the number of deals required is less than what it is supposed to be.
 	OldThreshold int
 
-	// Reader holds a user-specified entropy source used to create a random stream
+	// Reader is an optional field that can hold a user-specified entropy source.
+	// If it is set, Reader's data will be combined with random data from crypto/rand
+	// to create a random stream which will pick the dkg's secret coefficient. Otherwise,
+	// the random stream will only use crypto/rand's entropy.
 	Reader io.Reader
 
 	// UserReaderOnly forces the dkg's secretCoeff to be picked with randomness comming

--- a/share/dkg/pedersen/dkg.go
+++ b/share/dkg/pedersen/dkg.go
@@ -89,8 +89,8 @@ type Config struct {
 	// the random stream will only use crypto/rand's entropy.
 	Reader io.Reader
 
-	// UserReaderOnly forces the dkg's secretCoeff to be picked with randomness comming
-	// from the user only, allowing reproducibility
+	// When UserReaderOnly it set to true, it forces the dkg's secretCoeff to be
+	// picked with randomness comming from the user only, allowing reproducibility.
 	UserReaderOnly bool
 }
 

--- a/share/dkg/pedersen/dkg.go
+++ b/share/dkg/pedersen/dkg.go
@@ -10,10 +10,14 @@
 package dkg
 
 import (
+	"crypto/cipher"
+	"crypto/rand"
 	"errors"
 	"fmt"
+	"io"
 
 	"go.dedis.ch/kyber/v4"
+	"go.dedis.ch/kyber/v4/util/random"
 
 	"go.dedis.ch/kyber/v4/share"
 	vss "go.dedis.ch/kyber/v4/share/vss/pedersen"
@@ -78,6 +82,13 @@ type Config struct {
 	// absent) when doing a resharing to avoid a downgrade attack, where a resharing
 	// the number of deals required is less than what it is supposed to be.
 	OldThreshold int
+
+	// Reader holds a user-specified entropy source used to create a random stream
+	Reader io.Reader
+
+	// UserReaderOnly forces the dkg's secretCoeff to be picked with randomness comming
+	// from the user only, allowing reproducibility
+	UserReaderOnly bool
 }
 
 // DistKeyGenerator is the struct that runs the DKG protocol.
@@ -164,7 +175,18 @@ func NewDistKeyHandler(c *Config) (*DistKeyGenerator, error) {
 		canIssue = true
 	} else if !isResharing && newPresent {
 		// fresh DKG case
-		secretCoeff := c.Suite.Scalar().Pick(c.Suite.RandomStream())
+		var randomStream cipher.Stream
+		// empty reader, use entropy from crypto/rand
+		if c.Reader == nil {
+			randomStream = random.New()
+		} else { // use the reader they gave, alone or combined
+			if c.UserReaderOnly {
+				randomStream = random.New(c.Reader)
+			} else {
+				randomStream = random.New(c.Reader, rand.Reader)
+			}
+		}
+		secretCoeff := c.Suite.Scalar().Pick(randomStream)
 		dealer, err = vss.NewDealer(c.Suite, c.Longterm, secretCoeff, c.NewNodes, newThreshold)
 		canIssue = true
 		c.OldNodes = c.NewNodes

--- a/share/dkg/pedersen/dkg_test.go
+++ b/share/dkg/pedersen/dkg_test.go
@@ -4,6 +4,7 @@ import (
 	"crypto/rand"
 	"fmt"
 	mathRand "math/rand"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -1240,4 +1241,54 @@ func TestDKGResharingPartialNewNodes(t *testing.T) {
 	newSecret, err := share.RecoverSecret(suite, newSShares, newT, newN)
 	require.NoError(t, err)
 	require.Equal(t, oldSecret.String(), newSecret.String())
+}
+
+func TestDKGMixedEntropy(t *testing.T) {
+	r := strings.NewReader("some io.Reader stream to be read")
+	partPubs, partSec, _ := generate(defaultN, defaultT)
+
+	long := partSec[0]
+	c := &Config{
+		Suite:     suite,
+		Longterm:  long,
+		NewNodes:  partPubs,
+		Threshold: defaultT,
+		Reader:    r,
+	}
+	dkg, err := NewDistKeyHandler(c)
+	require.Nil(t, err)
+	require.NotNil(t, dkg.dealer)
+}
+
+func TestDKGUserOnly(t *testing.T) {
+	seed := "String to test reproducibility with"
+	partPubs, partSec, _ := generate(defaultN, defaultT)
+	long := partSec[0]
+	r1 := strings.NewReader(seed)
+	c1 := &Config{
+		Suite:          suite,
+		Longterm:       long,
+		NewNodes:       partPubs,
+		Threshold:      defaultT,
+		Reader:         r1,
+		UserReaderOnly: true,
+	}
+	dkg1, err := NewDistKeyHandler(c1)
+	require.Nil(t, err)
+	require.NotNil(t, dkg1.dealer)
+
+	r2 := strings.NewReader(seed)
+	c2 := &Config{
+		Suite:          suite,
+		Longterm:       long,
+		NewNodes:       partPubs,
+		Threshold:      defaultT,
+		Reader:         r2,
+		UserReaderOnly: true,
+	}
+	dkg2, err := NewDistKeyHandler(c2)
+	require.Nil(t, err)
+	require.NotNil(t, dkg2.dealer)
+
+	require.True(t, dkg1.dealer.PrivatePoly().Secret().Equal(dkg2.dealer.PrivatePoly().Secret()))
 }

--- a/share/dkg/pedersen/dkg_test.go
+++ b/share/dkg/pedersen/dkg_test.go
@@ -1244,20 +1244,36 @@ func TestDKGResharingPartialNewNodes(t *testing.T) {
 }
 
 func TestDKGMixedEntropy(t *testing.T) {
-	r := strings.NewReader("some io.Reader stream to be read")
+	seed := "some stream to be used with crypto/rand"
 	partPubs, partSec, _ := generate(defaultN, defaultT)
-
 	long := partSec[0]
-	c := &Config{
-		Suite:     suite,
-		Longterm:  long,
-		NewNodes:  partPubs,
-		Threshold: defaultT,
-		Reader:    r,
+	r1 := strings.NewReader(seed)
+	c1 := &Config{
+		Suite:          suite,
+		Longterm:       long,
+		NewNodes:       partPubs,
+		Threshold:      defaultT,
+		Reader:         r1,
+		UserReaderOnly: false,
 	}
-	dkg, err := NewDistKeyHandler(c)
+	dkg1, err := NewDistKeyHandler(c1)
 	require.Nil(t, err)
-	require.NotNil(t, dkg.dealer)
+	require.NotNil(t, dkg1.dealer)
+
+	r2 := strings.NewReader(seed)
+	c2 := &Config{
+		Suite:          suite,
+		Longterm:       long,
+		NewNodes:       partPubs,
+		Threshold:      defaultT,
+		Reader:         r2,
+		UserReaderOnly: false,
+	}
+	dkg2, err := NewDistKeyHandler(c2)
+	require.Nil(t, err)
+	require.NotNil(t, dkg2.dealer)
+
+	require.False(t, dkg1.dealer.PrivatePoly().Secret().Equal(dkg2.dealer.PrivatePoly().Secret()))
 }
 
 func TestDKGUserOnly(t *testing.T) {

--- a/share/dkg/pedersen/dkg_test.go
+++ b/share/dkg/pedersen/dkg_test.go
@@ -1243,43 +1243,28 @@ func TestDKGResharingPartialNewNodes(t *testing.T) {
 	require.Equal(t, oldSecret.String(), newSecret.String())
 }
 
-func TestDKGMixedEntropy(t *testing.T) {
+func TestReaderMixedEntropy(t *testing.T) {
 	seed := "some stream to be used with crypto/rand"
 	partPubs, partSec, _ := generate(defaultN, defaultT)
 	long := partSec[0]
-	r1 := strings.NewReader(seed)
-	c1 := &Config{
-		Suite:          suite,
-		Longterm:       long,
-		NewNodes:       partPubs,
-		Threshold:      defaultT,
-		Reader:         r1,
-		UserReaderOnly: false,
+	r := strings.NewReader(seed)
+	c := &Config{
+		Suite:     suite,
+		Longterm:  long,
+		NewNodes:  partPubs,
+		Threshold: defaultT,
+		Reader:    r,
 	}
-	dkg1, err := NewDistKeyHandler(c1)
+	dkg, err := NewDistKeyHandler(c)
 	require.Nil(t, err)
-	require.NotNil(t, dkg1.dealer)
-
-	r2 := strings.NewReader(seed)
-	c2 := &Config{
-		Suite:          suite,
-		Longterm:       long,
-		NewNodes:       partPubs,
-		Threshold:      defaultT,
-		Reader:         r2,
-		UserReaderOnly: false,
-	}
-	dkg2, err := NewDistKeyHandler(c2)
-	require.Nil(t, err)
-	require.NotNil(t, dkg2.dealer)
-
-	require.False(t, dkg1.dealer.PrivatePoly().Secret().Equal(dkg2.dealer.PrivatePoly().Secret()))
+	require.NotNil(t, dkg.dealer)
 }
 
-func TestDKGUserOnly(t *testing.T) {
+func TestUserOnlyFlagTrueBehavior(t *testing.T) {
 	seed := "String to test reproducibility with"
 	partPubs, partSec, _ := generate(defaultN, defaultT)
 	long := partSec[0]
+
 	r1 := strings.NewReader(seed)
 	c1 := &Config{
 		Suite:          suite,
@@ -1307,4 +1292,38 @@ func TestDKGUserOnly(t *testing.T) {
 	require.NotNil(t, dkg2.dealer)
 
 	require.True(t, dkg1.dealer.PrivatePoly().Secret().Equal(dkg2.dealer.PrivatePoly().Secret()))
+}
+
+func TestUserOnlyFlagFalseBehavior(t *testing.T) {
+	seed := "String to test reproducibility with"
+	partPubs, partSec, _ := generate(defaultN, defaultT)
+	long := partSec[0]
+
+	r1 := strings.NewReader(seed)
+	c1 := &Config{
+		Suite:          suite,
+		Longterm:       long,
+		NewNodes:       partPubs,
+		Threshold:      defaultT,
+		Reader:         r1,
+		UserReaderOnly: false,
+	}
+	dkg1, err := NewDistKeyHandler(c1)
+	require.Nil(t, err)
+	require.NotNil(t, dkg1.dealer)
+
+	r2 := strings.NewReader(seed)
+	c2 := &Config{
+		Suite:          suite,
+		Longterm:       long,
+		NewNodes:       partPubs,
+		Threshold:      defaultT,
+		Reader:         r2,
+		UserReaderOnly: false,
+	}
+	dkg2, err := NewDistKeyHandler(c2)
+	require.Nil(t, err)
+	require.NotNil(t, dkg2.dealer)
+
+	require.False(t, dkg1.dealer.PrivatePoly().Secret().Equal(dkg2.dealer.PrivatePoly().Secret()))
 }


### PR DESCRIPTION
PR adds two fields to perdersen dkg's configuration, both will be used to the instantiate a new randomStream to pick the secret coefficient:
- `Reader` can hold a user specified entropy source
- `userReaderOnly` boolean forces the use of the user's random data only for the secret coefficient generation (by default the user's data is always combined with randomness from crypto/rand). This is useful for reproducibility and debugging purposes 
