### PR TITLE
Schnorr signature verification with a null public key is an error

### DIFF
--- a/sign/eddsa/eddsa.go
+++ b/sign/eddsa/eddsa.go
@@ -122,6 +122,10 @@ func (e *EdDSA) Sign(msg []byte) ([]byte, error) {
 // Verify uses a public key, a message and a signature. It will return nil if
 // sig is a valid signature for msg created by key public, or an error otherwise.
 func Verify(public kyber.Point, msg, sig []byte) error {
+	if public.Equal(group.Point().Null()) {
+		return errors.New("invalid public key")
+	}
+
 	if len(sig) != 64 {
 		return fmt.Errorf("signature length invalid, expect 64 but got %v", len(sig))
 	}

--- a/sign/schnorr/schnorr.go
+++ b/sign/schnorr/schnorr.go
@@ -31,6 +31,7 @@ type Suite interface {
 // signature when using the edwards25519 Group.
 func Sign(s Suite, private kyber.Scalar, msg []byte) ([]byte, error) {
 	var g kyber.Group = s
+
 	// create random secret k and public point commitment R
 	k := g.Scalar().Pick(s.RandomStream())
 	R := g.Point().Mul(k, nil)
@@ -60,6 +61,9 @@ func Sign(s Suite, private kyber.Scalar, msg []byte) ([]byte, error) {
 // Verify verifies a given Schnorr signature. It returns nil iff the
 // given signature is valid.
 func Verify(g kyber.Group, public kyber.Point, msg, sig []byte) error {
+	if public.Equal(g.Point().Null()) {
+		return errors.New("invalid public key")
+	}
 	R := g.Point()
 	s := g.Scalar()
 	pointSize := R.MarshalSize()


### PR DESCRIPTION
Schnorr signatures are only defined for non-zero private keys because the
corresponding public key to a zero private key is the mulplicative identity,
causing the message hash to be excluded from the signature verification.

Do not allow null public keys so that if one is passed in by accident, Verify
returns an error instead of saying that the signature is good, even if the
message was modified.

It is still the caller's responsibility to use Kyber to make
valid secret keys.