### PR TITLE
Fixing schnorr.Verify

### DIFF
--- a/group.go
+++ b/group.go
@@ -163,3 +163,18 @@ type Group interface {
 	PointLen() int // Max length of point in bytes
 	Point() Point  // Create new point
 }
+
+// Ed25519Point is used to verify Ed25519 signatures
+// with checks around canonicality and group order
+type Ed25519Point interface {
+	Point
+	// HasSmallOrder checks if the given buffer (in little endian)
+	// represents a point with a small order
+	HasSmallOrder() bool
+}
+
+// Ed25519Scalar is used to verify Ed25519 signatures
+// with checks around canonicality and group order
+type Ed25519Scalar interface {
+	Scalar
+}

--- a/group/edwards25519/point.go
+++ b/group/edwards25519/point.go
@@ -263,3 +263,27 @@ func (P *point) HasSmallOrder() bool {
 
 	return (k>>8)&1 > 0
 }
+
+// PointIsCanonical determines whether the group element is canonical
+//
+// Checks whether group element s is less than p, according to RFC8032§5.1.3.1
+// https://tools.ietf.org/html/rfc8032#section-5.1.3
+//
+// Taken from
+// https://github.com/jedisct1/libsodium/blob/4744636721d2e420f8bbe2d563f31b1f5e682229/src/libsodium/crypto_core/ed25519/ref10/ed25519_ref10.c#L1113
+func PointIsCanonical(s []byte) bool {
+	if len(s) != 32 {
+		return false
+	}
+
+	c := (s[31] & 0x7f) ^ 0x7f
+	for i := 30; i > 0; i-- {
+		c |= s[i] ^ 0xff
+	}
+
+	// subtraction might underflow
+	c = byte((uint16(c) - 1) >> 8)
+	d := byte((0xed - 1 - uint16(s[0])) >> 8)
+
+	return 1-(c&d&1) == 1
+}

--- a/group/edwards25519/point_test.go
+++ b/group/edwards25519/point_test.go
@@ -23,3 +23,43 @@ func TestPoint_HasSmallOrder(t *testing.T) {
 		require.True(t, p.HasSmallOrder(), fmt.Sprintf("%s should be considered to have a small order", hex.EncodeToString(key)))
 	}
 }
+
+// Test_pointIsCanonical ensures that elements >= p are considered
+// non canonical
+func Test_pointIsCanonical(t *testing.T) {
+
+	// buffer stores the candidate points (in little endian) that we'll test
+	// against, starting with `prime`
+	buffer := prime.Bytes()
+	for i, j := 0, len(buffer)-1; i < j; i, j = i+1, j-1 {
+		buffer[i], buffer[j] = buffer[j], buffer[i]
+	}
+
+	// Iterate over the 19*2 finite field elements
+	var group = new(Curve)
+	point := group.Point()
+	actualNonCanonicalCount := 0
+	expectedNonCanonicalCount := 24
+	for i := 0; i < 19; i++ {
+		buffer[0] = byte(237 + i)
+		buffer[31] = byte(127)
+
+		// Check if it's a valid point on the curve that's
+		// not canonical
+		err := point.UnmarshalBinary(buffer)
+		if err == nil && !PointIsCanonical(buffer) {
+			actualNonCanonicalCount++
+		}
+
+		// flip bit
+		buffer[31] |= 128
+
+		// Check if it's a valid point on the curve that's
+		// not canonical
+		err = point.UnmarshalBinary(buffer)
+		if err == nil && !PointIsCanonical(buffer) {
+			actualNonCanonicalCount++
+		}
+	}
+	require.Equal(t, expectedNonCanonicalCount, actualNonCanonicalCount, "Incorrect number of non canonical points detected")
+}

--- a/group/edwards25519/scalar.go
+++ b/group/edwards25519/scalar.go
@@ -2230,3 +2230,31 @@ func scReduce(out *[32]byte, s *[64]byte) {
 	out[30] = byte(s11 >> 9)
 	out[31] = byte(s11 >> 17)
 }
+
+// ScalarIsCanonical whether scalar s is in the range 0<=s<L as required by RFC8032, Section 5.1.7.
+// Also provides Strong Unforgeability under Chosen Message Attacks (SUF-CMA)
+// See paper https://eprint.iacr.org/2020/823.pdf for definitions and theorems
+// See https://github.com/jedisct1/libsodium/blob/4744636721d2e420f8bbe2d563f31b1f5e682229/src/libsodium/crypto_core/ed25519/ref10/ed25519_ref10.c#L2568
+// for a reference
+func ScalarIsCanonical(sb []byte) bool {
+	if len(sb) != 32 {
+		return false
+	}
+
+	L := primeOrder.Bytes()
+	for i, j := 0, 31; i < j; i, j = i+1, j-1 {
+		L[i], L[j] = L[j], L[i]
+	}
+
+	var c byte
+	var n byte = 1
+
+	for i := 31; i >= 0; i-- {
+		// subtraction might lead to an underflow which needs
+		// to be accounted for in the right shift
+		c |= byte((uint16(sb[i])-uint16(L[i]))>>8) & n
+		n &= byte((uint16(sb[i]) ^ uint16(L[i]) - 1) >> 8)
+	}
+
+	return c != 0
+}

--- a/group/edwards25519/scalar_test.go
+++ b/group/edwards25519/scalar_test.go
@@ -2,6 +2,7 @@ package edwards25519
 
 import (
 	"fmt"
+	"math/big"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -456,4 +457,22 @@ func scSubFact(s, a, c *[32]byte) {
 	limbs[23] = int64(0)
 
 	scReduceLimbs(limbs)
+}
+
+func Test_scalarIsCanonical(t *testing.T) {
+	candidate := big.NewInt(-2)
+	candidate.Add(candidate, primeOrder)
+
+	candidateBuf := candidate.Bytes()
+	for i, j := 0, len(candidateBuf)-1; i < j; i, j = i+1, j-1 {
+		candidateBuf[i], candidateBuf[j] = candidateBuf[j], candidateBuf[i]
+	}
+
+	expected := []bool{true, true, false, false}
+
+	// We check in range [L-2, L+4)
+	for i := 0; i < 4; i++ {
+		require.Equal(t, expected[i], ScalarIsCanonical(candidateBuf), fmt.Sprintf("`lMinus2 + %d` does not pass canonicality test", i))
+		candidateBuf[0]++
+	}
 }

--- a/sign/eddsa/eddsa.go
+++ b/sign/eddsa/eddsa.go
@@ -7,18 +7,12 @@ import (
 	"crypto/sha512"
 	"errors"
 	"fmt"
-	"math/big"
 
 	"go.dedis.ch/kyber/v3"
 	"go.dedis.ch/kyber/v3/group/edwards25519"
 )
 
 var group = new(edwards25519.Curve)
-
-// TODO: maybe export prime and primeOrder from edwards25519/const or allow it to be
-// retrieved from the curve?
-var prime, _ = new(big.Int).SetString("57896044618658097711785492504343953926634992332820282019728792003956564819949", 10)
-var primeOrder, _ = new(big.Int).SetString("7237005577332262213973186563042994240857116359379907606001950938285454250989", 10)
 
 // EdDSA is a structure holding the data necessary to make a series of
 // EdDSA signatures.
@@ -30,15 +24,6 @@ type EdDSA struct {
 
 	seed   []byte
 	prefix []byte
-}
-
-// edDSAPoint is used to verify signatures
-// with checks around canonicality and group order
-type edDSAPoint interface {
-	kyber.Point
-	// HasSmallOrder checks if the given buffer (in little endian)
-	// represents a point with a small order
-	HasSmallOrder() bool
 }
 
 // NewEdDSA will return a freshly generated key pair to use for generating
@@ -143,21 +128,24 @@ func VerifyWithChecks(pub, msg, sig []byte) error {
 	if len(sig) != 64 {
 		return fmt.Errorf("signature length invalid, expect 64 but got %v", len(sig))
 	}
-	if !scalarIsCanonical(sig[32:]) {
+	// The goal of the first comparison is to prevent calling function scalarIsCanonical()
+	// in 99.999% of the cases, saving CPU cycles: this function is called if and only if any
+	// of the most significant 4 bits of sig[32:] are set
+	if (sig[63]&240) > 0 && !edwards25519.ScalarIsCanonical(sig[32:]) {
 		return fmt.Errorf("signature is not canonical")
 	}
-	if !pointIsCanonical(pub) {
+	if !edwards25519.PointIsCanonical(pub) {
 		return fmt.Errorf("public key is not canonical")
 	}
 
-	if !pointIsCanonical(sig[:32]) {
+	if !edwards25519.PointIsCanonical(sig[:32]) {
 		return fmt.Errorf("R is not canonical")
 	}
 	R := group.Point()
 	if err := R.UnmarshalBinary(sig[:32]); err != nil {
 		return fmt.Errorf("got R invalid point: %s", err)
 	}
-	if R.(edDSAPoint).HasSmallOrder() {
+	if R.(kyber.Ed25519Point).HasSmallOrder() {
 		return fmt.Errorf("R has small order")
 	}
 
@@ -170,7 +158,7 @@ func VerifyWithChecks(pub, msg, sig []byte) error {
 	if err := public.UnmarshalBinary(pub); err != nil {
 		return fmt.Errorf("invalid public key: %s", err)
 	}
-	if public.(edDSAPoint).HasSmallOrder() {
+	if public.(kyber.Ed25519Point).HasSmallOrder() {
 		return fmt.Errorf("public key has small order")
 	}
 
@@ -200,60 +188,4 @@ func Verify(public kyber.Point, msg, sig []byte) error {
 		return fmt.Errorf("error unmarshalling public key: %s", err)
 	}
 	return VerifyWithChecks(PBuf, msg, sig)
-}
-
-// scalarIsCanonical whether scalar s is in the range 0<=s<L as required by RFC8032, Section 5.1.7.
-// Also provides Strong Unforgeability under Chosen Message Attacks (SUF-CMA)
-// See paper https://eprint.iacr.org/2020/823.pdf for definitions and theorems
-// See https://github.com/jedisct1/libsodium/blob/4744636721d2e420f8bbe2d563f31b1f5e682229/src/libsodium/crypto_core/ed25519/ref10/ed25519_ref10.c#L2568
-// for a reference
-func scalarIsCanonical(sb []byte) bool {
-	if len(sb) != 32 {
-		return false
-	}
-
-	if sb[31]&0xf0 == 0 {
-		return true
-	}
-
-	L := primeOrder.Bytes()
-	for i, j := 0, 31; i < j; i, j = i+1, j-1 {
-		L[i], L[j] = L[j], L[i]
-	}
-
-	var c byte
-	var n byte = 1
-
-	for i := 31; i >= 0; i-- {
-		// subtraction might lead to an underflow which needs
-		// to be accounted for in the right shift
-		c |= byte((uint16(sb[i])-uint16(L[i]))>>8) & n
-		n &= byte((uint16(sb[i]) ^ uint16(L[i]) - 1) >> 8)
-	}
-
-	return c != 0
-}
-
-// pointIsCanonical determines whether the group element is canonical
-//
-// Checks whether group element s is less than p, according to RFC8032§5.1.3.1
-// https://tools.ietf.org/html/rfc8032#section-5.1.3
-//
-// Taken from
-// https://github.com/jedisct1/libsodium/blob/4744636721d2e420f8bbe2d563f31b1f5e682229/src/libsodium/crypto_core/ed25519/ref10/ed25519_ref10.c#L1113
-func pointIsCanonical(s []byte) bool {
-	if len(s) != 32 {
-		return false
-	}
-
-	c := (s[31] & 0x7f) ^ 0x7f
-	for i := 30; i > 0; i-- {
-		c |= s[i] ^ 0xff
-	}
-
-	// subtraction might underflow
-	c = byte((uint16(c) - 1) >> 8)
-	d := byte((0xed - 1 - uint16(s[0])) >> 8)
-
-	return 1-(c&d&1) == 1
 }

--- a/sign/eddsa/eddsa_test.go
+++ b/sign/eddsa/eddsa_test.go
@@ -6,8 +6,6 @@ import (
 	"compress/gzip"
 	"crypto/cipher"
 	"encoding/hex"
-	"fmt"
-	"math/big"
 	"math/rand"
 	"os"
 	"strings"
@@ -344,62 +342,5 @@ func TestGolden(t *testing.T) {
 
 	if err := scanner.Err(); err != nil {
 		t.Fatalf("error reading test data: %s", err)
-	}
-}
-
-// Test_pointIsCanonical ensures that elements >= p are considered
-// non canonical
-func Test_pointIsCanonical(t *testing.T) {
-
-	// buffer stores the candidate points (in little endian) that we'll test
-	// against, starting with `prime`
-	buffer := prime.Bytes()
-	for i, j := 0, len(buffer)-1; i < j; i, j = i+1, j-1 {
-		buffer[i], buffer[j] = buffer[j], buffer[i]
-	}
-
-	// Iterate over the 19*2 finite field elements
-	point := group.Point()
-	actualNonCanonicalCount := 0
-	expectedNonCanonicalCount := 24
-	for i := 0; i < 19; i++ {
-		buffer[0] = byte(237 + i)
-		buffer[31] = byte(127)
-
-		// Check if it's a valid point on the curve that's
-		// not canonical
-		err := point.UnmarshalBinary(buffer)
-		if err == nil && !pointIsCanonical(buffer) {
-			actualNonCanonicalCount++
-		}
-
-		// flip bit
-		buffer[31] |= 128
-
-		// Check if it's a valid point on the curve that's
-		// not canonical
-		err = point.UnmarshalBinary(buffer)
-		if err == nil && !pointIsCanonical(buffer) {
-			actualNonCanonicalCount++
-		}
-	}
-	require.Equal(t, expectedNonCanonicalCount, actualNonCanonicalCount, "Incorrect number of non canonical points detected")
-}
-
-func Test_scalarIsCanonical(t *testing.T) {
-	candidate := big.NewInt(-2)
-	candidate.Add(candidate, primeOrder)
-
-	candidateBuf := candidate.Bytes()
-	for i, j := 0, len(candidateBuf)-1; i < j; i, j = i+1, j-1 {
-		candidateBuf[i], candidateBuf[j] = candidateBuf[j], candidateBuf[i]
-	}
-
-	expected := []bool{true, true, false, false}
-
-	// We check in range [L-2, L+4)
-	for i := 0; i < 4; i++ {
-		require.Equal(t, expected[i], scalarIsCanonical(candidateBuf), fmt.Sprintf("`lMinus2 + %d` does not pass canonicality test", i))
-		candidateBuf[0]++
 	}
 }

--- a/sign/schnorr/schnorr_test.go
+++ b/sign/schnorr/schnorr_test.go
@@ -64,6 +64,16 @@ func TestEdDSACompatibility(t *testing.T) {
 		t.Fatalf("Couldn't verify signature: \n%+v\nfor msg:'%s'. Error:\n%v", s, msg, err)
 	}
 
+	ed := eddsa.NewEdDSA(suite.RandomStream())
+	s2, err := ed.Sign(msg)
+	if err != nil {
+		t.Fatalf("Couldn't sign msg (eddsa.Sign): %s: %v", msg, err)
+	}
+	err = Verify(suite, ed.Public, msg, s2)
+	if err != nil {
+		t.Fatalf("Couldn't verify signature (schnorr.Verify): \n%+v\nfor msg:'%s'. Error:\n%v", s, msg, err)
+	}
+
 }
 
 // Simple random stream using the random instance provided by the testing tool

--- a/sign/schnorr/schnorr_test.go
+++ b/sign/schnorr/schnorr_test.go
@@ -76,6 +76,41 @@ func TestEdDSACompatibility(t *testing.T) {
 
 }
 
+func TestSchnorrMalleability(t *testing.T) {
+	/* l = 2^252+27742317777372353535851937790883648493, prime order of the base point */
+	var L []uint16 = []uint16{0xed, 0xd3, 0xf5, 0x5c, 0x1a, 0x63, 0x12, 0x58, 0xd6, 0x9c, 0xf7,
+		0xa2, 0xde, 0xf9, 0xde, 0x14, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+		0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x10}
+	var c uint16 = 0
+
+	msg := []byte("Hello Schnorr")
+	suite := edwards25519.NewBlakeSHA256Ed25519()
+	kp := key.NewKeyPair(suite)
+
+	s, err := Sign(suite, kp.Private, msg)
+	if err != nil {
+		t.Fatalf("Couldn't sign msg: %s: %v", msg, err)
+	}
+
+	err = Verify(suite, kp.Public, msg, s)
+	if err != nil {
+		t.Fatalf("Couldn't verify signature (schnorr.Verify): \n%+v\nfor msg:'%s'. Error:\n%v", s, msg, err)
+	}
+
+	// Add l to signature
+	for i := 0; i < 32; i++ {
+		c += uint16(s[32+i]) + L[i]
+		s[32+i] = byte(c)
+		c >>= 8
+	}
+	assert.Error(t, eddsa.Verify(kp.Public, msg, s))
+
+	err = Verify(suite, kp.Public, msg, s)
+	if err == nil {
+		t.Fatalf("OH NO, SCHNORR SIGNATURES ARE MALLEABLE!")
+	}
+}
+
 // Simple random stream using the random instance provided by the testing tool
 type quickstream struct {
 	rand *rand.Rand


### PR DESCRIPTION
This PR fixes the [latest PR](https://github.com/dedis/kyber/pull/430) because it didn't fix schnorr.Verify as previously [suggested in PR #427](https://github.com/dedis/kyber/pull/427):

- Added schnorr.VerifyWithChecks(g kyber.Group, pub, msg, sig []byte) which checks constraints as imposed by RFC8032 and group order checks
- Expanded the test TestEdDSACompatibility to check the reverse compatibility (i.e., an EdDSA signature can be checked by schnorr.Verify).
- Refactored tests and functions to leave them in their proper place

Fixes #431