### PR TITLE
Support bls12-381 in pairing

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,11 +1,12 @@
 module go.dedis.ch/kyber/v3
 
 require (
+	github.com/kilic/bls12-381 v0.1.0
 	github.com/stretchr/testify v1.3.0
 	go.dedis.ch/fixbuf v1.0.3
 	go.dedis.ch/protobuf v1.0.11
 	golang.org/x/crypto v0.0.0-20190123085648-057139ce5d2b
-	golang.org/x/sys v0.0.0-20190124100055-b90733256f2e
+	golang.org/x/sys v0.0.0-20201101102859-da207088b7d1
 )
 
 go 1.13

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,7 @@
 github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/kilic/bls12-381 v0.1.0 h1:encrdjqKMEvabVQ7qYOKu1OvhqpK4s47wDYtNiPtlp4=
+github.com/kilic/bls12-381 v0.1.0/go.mod h1:vDTTHJONJ6G+P2R74EhnyotQDTliQDnFEwhdmfzw1ig=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
@@ -20,3 +22,5 @@ golang.org/x/crypto v0.0.0-20190123085648-057139ce5d2b h1:Elez2XeF2p9uyVj0yEUDqQ
 golang.org/x/crypto v0.0.0-20190123085648-057139ce5d2b/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
 golang.org/x/sys v0.0.0-20190124100055-b90733256f2e h1:3GIlrlVLfkoipSReOMNAgApI0ajnalyLa/EZHHca/XI=
 golang.org/x/sys v0.0.0-20190124100055-b90733256f2e/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
+golang.org/x/sys v0.0.0-20201101102859-da207088b7d1 h1:a/mKvvZr9Jcc8oKfcmgzyp7OwF73JPWsQLvH1z2Kxck=
+golang.org/x/sys v0.0.0-20201101102859-da207088b7d1/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=

--- a/pairing/bls12381/LICENSE
+++ b/pairing/bls12381/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2020 drand
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/pairing/bls12381/group.go
+++ b/pairing/bls12381/group.go
@@ -1,0 +1,120 @@
+package bls12381
+
+import (
+	"crypto/cipher"
+	"crypto/sha256"
+	"hash"
+
+	"go.dedis.ch/kyber/v3"
+	"go.dedis.ch/kyber/v3/util/random"
+	"go.dedis.ch/kyber/v3/xof/blake2xb"
+)
+
+// GroupChecker allows to verify if a Point is in the correct group or not. For
+// curves which don't have a prime order, we need to only consider the points
+// lying in the subgroup of prime order. That check returns true if the point is
+// correct or not.
+type GroupChecker interface {
+	kyber.Point
+	IsInCorrectGroup() bool
+}
+
+type common struct {
+	isPrime bool
+}
+
+func (g *common) Scalar() kyber.Scalar {
+	return NewKyberScalar()
+}
+
+func (g *common) ScalarLen() int {
+	return g.Scalar().MarshalSize()
+}
+
+func (g *common) IsPrimeOrder() bool {
+	return g.isPrime
+}
+
+func (g *common) Hash() hash.Hash {
+	return sha256.New()
+}
+
+// XOF returns a newlly instantiated blake2xb XOF function.
+func (g *common) XOF(seed []byte) kyber.XOF {
+	return blake2xb.New(seed)
+}
+
+// RandomStream returns a cipher.Stream which corresponds to a key stream from
+// crypto/rand.
+func (g *common) RandomStream() cipher.Stream {
+	return random.New()
+}
+
+type groupG1 struct {
+	common
+	*commonSuite
+}
+
+func (g *groupG1) String() string {
+	return "bls12381.G1"
+}
+
+func (g *groupG1) Point() kyber.Point {
+	return NullpointG1()
+}
+
+func (g *groupG1) PointLen() int {
+	return g.Point().MarshalSize()
+}
+
+type groupG2 struct {
+	common
+	*commonSuite
+}
+
+func (g *groupG2) String() string {
+	return "bls12381.G2"
+}
+
+func (g *groupG2) Point() kyber.Point {
+	return NullpointG2()
+}
+
+func (g *groupG2) PointLen() int {
+	return g.Point().MarshalSize()
+}
+
+type groupGT struct {
+	common
+	*commonSuite
+}
+
+func (g *groupGT) String() string {
+	return "bls12381.GT"
+}
+
+func (g *groupGT) Point() kyber.Point {
+	return newEmptyGT()
+}
+
+func (g *groupGT) PointLen() int {
+	return g.Point().MarshalSize()
+}
+
+func NewGroupG1() kyber.Group {
+	return &groupG1{
+		common: common{isPrime: true},
+	}
+}
+
+func NewGroupG2() kyber.Group {
+	return &groupG2{
+		common: common{isPrime: false},
+	}
+}
+
+func NewGroupGT() kyber.Group {
+	return &groupGT{
+		common: common{isPrime: false},
+	}
+}

--- a/pairing/bls12381/group.go
+++ b/pairing/bls12381/group.go
@@ -60,7 +60,7 @@ func (g *groupG1) String() string {
 }
 
 func (g *groupG1) Point() kyber.Point {
-	return NullpointG1()
+	return nullpointG1()
 }
 
 func (g *groupG1) PointLen() int {
@@ -77,7 +77,7 @@ func (g *groupG2) String() string {
 }
 
 func (g *groupG2) Point() kyber.Point {
-	return NullpointG2()
+	return nullpointG2()
 }
 
 func (g *groupG2) PointLen() int {
@@ -101,20 +101,14 @@ func (g *groupGT) PointLen() int {
 	return g.Point().MarshalSize()
 }
 
-func NewGroupG1() kyber.Group {
+func newGroupG1() kyber.Group {
 	return &groupG1{
 		common: common{isPrime: true},
 	}
 }
 
-func NewGroupG2() kyber.Group {
+func newGroupG2() kyber.Group {
 	return &groupG2{
-		common: common{isPrime: false},
-	}
-}
-
-func NewGroupGT() kyber.Group {
-	return &groupGT{
 		common: common{isPrime: false},
 	}
 }

--- a/pairing/bls12381/point.go
+++ b/pairing/bls12381/point.go
@@ -16,7 +16,7 @@ type pointG1 struct {
 	p *bls12381.PointG1
 }
 
-func NullpointG1() *pointG1 {
+func nullpointG1() *pointG1 {
 	var p bls12381.PointG1
 	return newPointG1(&p)
 }
@@ -88,7 +88,7 @@ func (k *pointG1) Neg(a kyber.Point) kyber.Point {
 
 func (k *pointG1) Mul(s kyber.Scalar, q kyber.Point) kyber.Point {
 	if q == nil {
-		q = NullpointG1().Base()
+		q = nullpointG1().Base()
 	}
 	bls12381.NewG1().MulScalarBig(
 		k.p,
@@ -154,7 +154,7 @@ type pointG2 struct {
 	p *bls12381.PointG2
 }
 
-func NullpointG2() *pointG2 {
+func nullpointG2() *pointG2 {
 	var p bls12381.PointG2
 	return newPointG2(&p)
 }
@@ -226,7 +226,7 @@ func (k *pointG2) Neg(a kyber.Point) kyber.Point {
 
 func (k *pointG2) Mul(s kyber.Scalar, q kyber.Point) kyber.Point {
 	if q == nil {
-		q = NullpointG2().Base()
+		q = nullpointG2().Base()
 	}
 	bls12381.NewG2().MulScalarBig(
 		k.p,

--- a/pairing/bls12381/point.go
+++ b/pairing/bls12381/point.go
@@ -1,0 +1,403 @@
+package bls12381
+
+import (
+	"crypto/cipher"
+	"crypto/sha256"
+	"encoding/hex"
+	"io"
+
+	bls12381 "github.com/kilic/bls12-381"
+	"go.dedis.ch/kyber/v3"
+	"go.dedis.ch/kyber/v3/group/mod"
+)
+
+// pointG1 is a kyber.Point holding a G1 point on BLS12-381 curve
+type pointG1 struct {
+	p *bls12381.PointG1
+}
+
+func NullpointG1() *pointG1 {
+	var p bls12381.PointG1
+	return newPointG1(&p)
+}
+
+func newPointG1(p *bls12381.PointG1) *pointG1 {
+	return &pointG1{p: p}
+}
+
+func (k *pointG1) Equal(k2 kyber.Point) bool {
+	return bls12381.NewG1().Equal(k.p, k2.(*pointG1).p)
+}
+
+func (k *pointG1) Null() kyber.Point {
+	return newPointG1(bls12381.NewG1().Zero())
+}
+
+func (k *pointG1) Base() kyber.Point {
+	return newPointG1(bls12381.NewG1().One())
+}
+
+func (k *pointG1) Pick(rand cipher.Stream) kyber.Point {
+	var dst, src [32]byte
+	rand.XORKeyStream(dst[:], src[:])
+	return k.Hash(dst[:])
+}
+
+func (k *pointG1) Set(q kyber.Point) kyber.Point {
+	k.p.Set(q.(*pointG1).p)
+	return k
+}
+
+func (k *pointG1) Clone() kyber.Point {
+	var p bls12381.PointG1
+	p.Set(k.p)
+	return newPointG1(&p)
+}
+
+func (k *pointG1) EmbedLen() int {
+	panic("bls12-381: unsupported operation")
+}
+
+func (k *pointG1) Embed(data []byte, rand cipher.Stream) kyber.Point {
+	panic("bls12-381: unsupported operation")
+}
+
+func (k *pointG1) Data() ([]byte, error) {
+	panic("bls12-381: unsupported operation")
+}
+
+func (k *pointG1) Add(a, b kyber.Point) kyber.Point {
+	aa := a.(*pointG1)
+	bb := b.(*pointG1)
+	bls12381.NewG1().Add(k.p, aa.p, bb.p)
+	return k
+}
+
+func (k *pointG1) Sub(a, b kyber.Point) kyber.Point {
+	aa := a.(*pointG1)
+	bb := b.(*pointG1)
+	bls12381.NewG1().Sub(k.p, aa.p, bb.p)
+	return k
+}
+
+func (k *pointG1) Neg(a kyber.Point) kyber.Point {
+	aa := a.(*pointG1)
+	bls12381.NewG1().Neg(k.p, aa.p)
+	return k
+}
+
+func (k *pointG1) Mul(s kyber.Scalar, q kyber.Point) kyber.Point {
+	if q == nil {
+		q = NullpointG1().Base()
+	}
+	bls12381.NewG1().MulScalarBig(
+		k.p,
+		q.(*pointG1).p,
+		&s.(*mod.Int).V,
+	)
+	return k
+}
+
+func (k *pointG1) MarshalBinary() ([]byte, error) {
+	return bls12381.NewG1().ToCompressed(k.p), nil
+}
+
+func (k *pointG1) UnmarshalBinary(buff []byte) error {
+	var err error
+	k.p, err = bls12381.NewG1().FromCompressed(buff)
+	return err
+}
+
+func (k *pointG1) MarshalTo(w io.Writer) (int, error) {
+	buf, err := k.MarshalBinary()
+	if err != nil {
+		return 0, err
+	}
+	return w.Write(buf)
+}
+
+func (k *pointG1) UnmarshalFrom(r io.Reader) (int, error) {
+	buf := make([]byte, k.MarshalSize())
+	n, err := io.ReadFull(r, buf)
+	if err != nil {
+		return n, err
+	}
+	return n, k.UnmarshalBinary(buf)
+}
+
+func (k *pointG1) MarshalSize() int {
+	return 48
+}
+
+func (k *pointG1) String() string {
+	b, _ := k.MarshalBinary()
+	return "bls12-381.G1: " + hex.EncodeToString(b)
+}
+
+func (k *pointG1) Hash(m []byte) kyber.Point {
+	p, _ := bls12381.NewG1().HashToCurve(m, Domain)
+	k.p = p
+	return k
+
+}
+
+func (k *pointG1) IsInCorrectGroup() bool {
+	return bls12381.NewG1().InCorrectSubgroup(k.p)
+}
+
+// Domain comes from the ciphersuite used by the RFC of this name compatible
+// with the paired library > v18
+var Domain = []byte("BLS_SIG_BLS12381G2_XMD:SHA-256_SSWU_RO_NUL_")
+
+// pointG2 is a kyber.Point holding a G2 point on BLS12-381 curve
+type pointG2 struct {
+	p *bls12381.PointG2
+}
+
+func NullpointG2() *pointG2 {
+	var p bls12381.PointG2
+	return newPointG2(&p)
+}
+
+func newPointG2(p *bls12381.PointG2) *pointG2 {
+	return &pointG2{p: p}
+}
+
+func (k *pointG2) Equal(k2 kyber.Point) bool {
+	return bls12381.NewG2().Equal(k.p, k2.(*pointG2).p)
+}
+
+func (k *pointG2) Null() kyber.Point {
+	return newPointG2(bls12381.NewG2().Zero())
+}
+
+func (k *pointG2) Base() kyber.Point {
+	return newPointG2(bls12381.NewG2().One())
+}
+
+func (k *pointG2) Pick(rand cipher.Stream) kyber.Point {
+	var dst, src [32]byte
+	rand.XORKeyStream(dst[:], src[:])
+	return k.Hash(dst[:])
+}
+
+func (k *pointG2) Set(q kyber.Point) kyber.Point {
+	k.p.Set(q.(*pointG2).p)
+	return k
+}
+
+func (k *pointG2) Clone() kyber.Point {
+	var p bls12381.PointG2
+	p.Set(k.p)
+	return newPointG2(&p)
+}
+
+func (k *pointG2) EmbedLen() int {
+	panic("bls12-381: unsupported operation")
+}
+
+func (k *pointG2) Embed(data []byte, rand cipher.Stream) kyber.Point {
+	panic("bls12-381: unsupported operation")
+}
+
+func (k *pointG2) Data() ([]byte, error) {
+	panic("bls12-381: unsupported operation")
+}
+
+func (k *pointG2) Add(a, b kyber.Point) kyber.Point {
+	aa := a.(*pointG2)
+	bb := b.(*pointG2)
+	bls12381.NewG2().Add(k.p, aa.p, bb.p)
+	return k
+}
+
+func (k *pointG2) Sub(a, b kyber.Point) kyber.Point {
+	aa := a.(*pointG2)
+	bb := b.(*pointG2)
+	bls12381.NewG2().Sub(k.p, aa.p, bb.p)
+	return k
+}
+
+func (k *pointG2) Neg(a kyber.Point) kyber.Point {
+	aa := a.(*pointG2)
+	bls12381.NewG2().Neg(k.p, aa.p)
+	return k
+}
+
+func (k *pointG2) Mul(s kyber.Scalar, q kyber.Point) kyber.Point {
+	if q == nil {
+		q = NullpointG2().Base()
+	}
+	bls12381.NewG2().MulScalarBig(
+		k.p,
+		q.(*pointG2).p,
+		&s.(*mod.Int).V,
+	)
+	return k
+}
+
+func (k *pointG2) MarshalBinary() ([]byte, error) {
+	return bls12381.NewG2().ToCompressed(k.p), nil
+}
+
+func (k *pointG2) UnmarshalBinary(buff []byte) error {
+	var err error
+	k.p, err = bls12381.NewG2().FromCompressed(buff)
+	return err
+}
+
+func (k *pointG2) MarshalTo(w io.Writer) (int, error) {
+	buf, err := k.MarshalBinary()
+	if err != nil {
+		return 0, err
+	}
+	return w.Write(buf)
+}
+
+func (k *pointG2) UnmarshalFrom(r io.Reader) (int, error) {
+	buf := make([]byte, k.MarshalSize())
+	n, err := io.ReadFull(r, buf)
+	if err != nil {
+		return n, err
+	}
+	return n, k.UnmarshalBinary(buf)
+}
+
+func (k *pointG2) MarshalSize() int {
+	return 96
+}
+
+func (k *pointG2) String() string {
+	b, _ := k.MarshalBinary()
+	return "bls12-381.G1: " + hex.EncodeToString(b)
+}
+
+func (k *pointG2) Hash(m []byte) kyber.Point {
+	pg2, _ := bls12381.NewG2().HashToCurve(m, Domain)
+	k.p = pg2
+	return k
+}
+
+func sha256Hash(in []byte) []byte {
+	h := sha256.New()
+	h.Write(in)
+	return h.Sum(nil)
+}
+
+func (k *pointG2) IsInCorrectGroup() bool {
+	return bls12381.NewG2().InCorrectSubgroup(k.p)
+}
+
+type pointGT struct {
+	f *bls12381.E
+}
+
+func newEmptyGT() *pointGT {
+	return newPointGT(bls12381.NewGT().New())
+}
+func newPointGT(f *bls12381.E) *pointGT {
+	return &pointGT{
+		f: f,
+	}
+}
+
+func (k *pointGT) Equal(kk kyber.Point) bool {
+	return k.f.Equal(kk.(*pointGT).f)
+}
+
+const gtLength = 576
+
+func (k *pointGT) Null() kyber.Point {
+	var zero [gtLength]byte
+	k.f, _ = bls12381.NewGT().FromBytes(zero[:])
+	return k
+}
+
+func (k *pointGT) Base() kyber.Point {
+	panic("not yet available")
+}
+
+func (k *pointGT) Pick(rand cipher.Stream) kyber.Point {
+	panic("TODO: bls12-381.GT.Pick()")
+}
+
+func (k *pointGT) Set(q kyber.Point) kyber.Point {
+	k.f.Set(q.(*pointGT).f)
+	return k
+}
+
+func (k *pointGT) Clone() kyber.Point {
+	kk := newEmptyGT()
+	kk.Set(k)
+	return kk
+}
+
+func (k *pointGT) Add(a, b kyber.Point) kyber.Point {
+	aa := a.(*pointGT)
+	bb := b.(*pointGT)
+	bls12381.NewGT().Mul(k.f, aa.f, bb.f)
+	return k
+}
+
+func (k *pointGT) Sub(a, b kyber.Point) kyber.Point {
+	aa := a.(*pointGT)
+	bb := b.(*pointGT)
+	bls12381.NewGT().Sub(k.f, aa.f, bb.f)
+	return k
+}
+
+func (k *pointGT) Neg(q kyber.Point) kyber.Point {
+	panic("bls12-381: GT is not a full kyber.Point implementation")
+}
+
+func (k *pointGT) Mul(s kyber.Scalar, q kyber.Point) kyber.Point {
+	panic("bls12-381: GT is not a full kyber.Point implementation")
+}
+
+func (k *pointGT) MarshalBinary() ([]byte, error) {
+	return bls12381.NewGT().ToBytes(k.f), nil
+}
+
+func (k *pointGT) MarshalTo(w io.Writer) (int, error) {
+	buf, err := k.MarshalBinary()
+	if err != nil {
+		return 0, err
+	}
+	return w.Write(buf)
+}
+
+func (k *pointGT) UnmarshalBinary(buf []byte) error {
+	fe12, err := bls12381.NewGT().FromBytes(buf)
+	k.f = fe12
+	return err
+}
+
+func (k *pointGT) UnmarshalFrom(r io.Reader) (int, error) {
+	buf := make([]byte, k.MarshalSize())
+	n, err := io.ReadFull(r, buf)
+	if err != nil {
+		return n, err
+	}
+	return n, k.UnmarshalBinary(buf)
+}
+
+func (k *pointGT) MarshalSize() int {
+	return 576
+}
+
+func (k *pointGT) String() string {
+	b, _ := k.MarshalBinary()
+	return "bls12-381.GT: " + hex.EncodeToString(b)
+}
+
+func (k *pointGT) EmbedLen() int {
+	panic("bls12-381.GT.EmbedLen(): unsupported operation")
+}
+
+func (k *pointGT) Embed(data []byte, rand cipher.Stream) kyber.Point {
+	panic("bls12-381.GT.Embed(): unsupported operation")
+}
+
+func (k *pointGT) Data() ([]byte, error) {
+	panic("bls12-381.GT.Data(): unsupported operation")
+}

--- a/pairing/bls12381/scalar.go
+++ b/pairing/bls12381/scalar.go
@@ -1,0 +1,14 @@
+package bls12381
+
+import (
+	"math/big"
+
+	"go.dedis.ch/kyber/v3"
+	"go.dedis.ch/kyber/v3/group/mod"
+)
+
+var curveOrder, _ = new(big.Int).SetString("73eda753299d7d483339d80809a1d80553bda402fffe5bfeffffffff00000001", 16)
+
+func NewKyberScalar() kyber.Scalar {
+	return mod.NewInt64(0, curveOrder)
+}

--- a/pairing/bls12381/scalar.go
+++ b/pairing/bls12381/scalar.go
@@ -9,6 +9,7 @@ import (
 
 var curveOrder, _ = new(big.Int).SetString("73eda753299d7d483339d80809a1d80553bda402fffe5bfeffffffff00000001", 16)
 
+// NewKyberScalar returns a new scalar value
 func NewKyberScalar() kyber.Scalar {
 	return mod.NewInt64(0, curveOrder)
 }

--- a/pairing/bls12381/suite.go
+++ b/pairing/bls12381/suite.go
@@ -77,6 +77,8 @@ func (s *Suite) GT() kyber.Group {
 	return s.gt
 }
 
+// ValidatePairing is a simpler way to verify a pairing equation.
+// e(p1,p2) =?= e(inv1^-1, inv2^-1)
 func (s *Suite) ValidatePairing(p1, p2, p3, p4 kyber.Point) bool {
 	e := bls12381.NewEngine()
 	e.AddPair(p1.(*pointG1).p, p2.(*pointG2).p)
@@ -84,6 +86,8 @@ func (s *Suite) ValidatePairing(p1, p2, p3, p4 kyber.Point) bool {
 	return e.Check()
 }
 
+// Pair takes the points p1 and p2 in groups G1 and G2, respectively, as input
+// and computes their pairing in GT.
 func (s *Suite) Pair(p1, p2 kyber.Point) kyber.Point {
 	e := bls12381.NewEngine()
 	g1point := p1.(*pointG1).p

--- a/pairing/bls12381/suite.go
+++ b/pairing/bls12381/suite.go
@@ -1,0 +1,171 @@
+package bls12381
+
+import (
+	"crypto/cipher"
+	"crypto/sha256"
+	"hash"
+	"io"
+	"reflect"
+
+	bls12381 "github.com/kilic/bls12-381"
+	"go.dedis.ch/fixbuf"
+	"go.dedis.ch/kyber/v3"
+	"go.dedis.ch/kyber/v3/util/random"
+	"go.dedis.ch/kyber/v3/xof/blake2xb"
+)
+
+// Suite implements the pairing.Suite interface for the Bls12381 bilinear pairing.
+type Suite struct {
+	*commonSuite
+	g1 *groupG1
+	g2 *groupG2
+	gt *groupGT
+}
+
+// NewSuite generates and returns a new Bls12381 pairing suite.
+func NewSuite() *Suite {
+	s := &Suite{commonSuite: &commonSuite{}}
+	s.g1 = &groupG1{commonSuite: s.commonSuite, common: common{isPrime: true}}
+	s.g2 = &groupG2{commonSuite: s.commonSuite, common: common{isPrime: false}}
+	s.gt = &groupGT{commonSuite: s.commonSuite, common: common{isPrime: false}}
+	return s
+}
+
+// NewSuiteG1 returns a G1 suite.
+func NewSuiteG1() *Suite {
+	s := NewSuite()
+	s.commonSuite.Group = &groupG1{commonSuite: &commonSuite{}, common: common{isPrime: true}}
+	return s
+}
+
+// NewSuiteG2 returns a G2 suite.
+func NewSuiteG2() *Suite {
+	s := NewSuite()
+	s.commonSuite.Group = &groupG2{commonSuite: &commonSuite{}, common: common{isPrime: true}}
+	return s
+}
+
+// NewSuiteGT returns a GT suite.
+func NewSuiteGT() *Suite {
+	s := NewSuite()
+	s.commonSuite.Group = &groupGT{commonSuite: &commonSuite{}, common: common{isPrime: true}}
+	return s
+}
+
+// NewSuiteRand generates and returns a new BN256 suite seeded by the
+// given cipher stream.
+func NewSuiteRand(rand cipher.Stream) *Suite {
+	s := &Suite{commonSuite: &commonSuite{s: rand}}
+	s.g1 = &groupG1{commonSuite: s.commonSuite, common: common{isPrime: true}}
+	s.g2 = &groupG2{commonSuite: s.commonSuite, common: common{isPrime: false}}
+	s.gt = &groupGT{commonSuite: s.commonSuite, common: common{isPrime: false}}
+	return s
+}
+
+// G1 returns the group G1 of the BN256 pairing.
+func (s *Suite) G1() kyber.Group {
+	return s.g1
+}
+
+// G2 returns the group G2 of the BN256 pairing.
+func (s *Suite) G2() kyber.Group {
+	return s.g2
+}
+
+// GT returns the group GT of the BN256 pairing.
+func (s *Suite) GT() kyber.Group {
+	return s.gt
+}
+
+func (s *Suite) ValidatePairing(p1, p2, p3, p4 kyber.Point) bool {
+	e := bls12381.NewEngine()
+	e.AddPair(p1.(*pointG1).p, p2.(*pointG2).p)
+	e.AddPairInv(p3.(*pointG1).p, p4.(*pointG2).p)
+	return e.Check()
+}
+
+func (s *Suite) Pair(p1, p2 kyber.Point) kyber.Point {
+	e := bls12381.NewEngine()
+	g1point := p1.(*pointG1).p
+	g2point := p2.(*pointG2).p
+	return newPointGT(e.AddPair(g1point, g2point).Result())
+}
+
+// Not used other than for reflect.TypeOf()
+var aScalar kyber.Scalar
+var aPoint kyber.Point
+var aPointG1 pointG1
+var aPointG2 pointG2
+var aPointGT pointGT
+
+var tScalar = reflect.TypeOf(&aScalar).Elem()
+var tPoint = reflect.TypeOf(&aPoint).Elem()
+var tPointG1 = reflect.TypeOf(&aPointG1).Elem()
+var tPointG2 = reflect.TypeOf(&aPointG2).Elem()
+var tPointGT = reflect.TypeOf(&aPointGT).Elem()
+
+type commonSuite struct {
+	s cipher.Stream
+	// kyber.Group is only set if we have a combined Suite
+	kyber.Group
+}
+
+// New implements the kyber.Encoding interface.
+func (c *commonSuite) New(t reflect.Type) interface{} {
+	if c.Group == nil {
+		panic("cannot create Point from NewGroup - please use bls12381.NewGroupG1")
+	}
+	switch t {
+	case tScalar:
+		return c.Scalar()
+	case tPoint:
+		return c.Point()
+	case tPointG1:
+		g1 := groupG1{}
+		return g1.Point()
+	case tPointG2:
+		g2 := groupG2{}
+		return g2.Point()
+	case tPointGT:
+		gt := groupGT{}
+		return gt.Point()
+	}
+	return nil
+}
+
+// Read is the default implementation of kyber.Encoding interface Read.
+func (c *commonSuite) Read(r io.Reader, objs ...interface{}) error {
+	return fixbuf.Read(r, c, objs...)
+}
+
+// Write is the default implementation of kyber.Encoding interface Write.
+func (c *commonSuite) Write(w io.Writer, objs ...interface{}) error {
+	return fixbuf.Write(w, objs)
+}
+
+// Hash returns a newly instantiated sha256 hash function.
+func (c *commonSuite) Hash() hash.Hash {
+	return sha256.New()
+}
+
+// XOF returns a newlly instantiated blake2xb XOF function.
+func (c *commonSuite) XOF(seed []byte) kyber.XOF {
+	return blake2xb.New(seed)
+}
+
+// RandomStream returns a cipher.Stream which corresponds to a key stream from
+// crypto/rand.
+func (c *commonSuite) RandomStream() cipher.Stream {
+	if c.s != nil {
+		return c.s
+	}
+	return random.New()
+}
+
+// String returns a recognizable string that this is a combined suite.
+func (c commonSuite) String() string {
+	if c.Group != nil {
+		return c.Group.String()
+	}
+	return "bls12381"
+}

--- a/pairing/bls12381/suite_test.go
+++ b/pairing/bls12381/suite_test.go
@@ -1,0 +1,365 @@
+package bls12381
+
+import (
+	"bytes"
+	"crypto/cipher"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.dedis.ch/kyber/v3"
+	"go.dedis.ch/kyber/v3/util/random"
+)
+
+// Code extracted from kyber/utils/test
+// TODO: expose API in forked drand/kyber
+// Apply a generic set of validation tests to a cryptographic Group,
+// using a given source of [pseudo-]randomness.
+//
+// Returns a log of the pseudorandom Points produced in the test,
+// for comparison across alternative implementations
+// that are supposed to be equivalent.
+func testGroup(t *testing.T, g kyber.Group, rand cipher.Stream) []kyber.Point {
+	t.Logf("\nTesting group '%s': %d-byte Point, %d-byte Scalar\n",
+		g.String(), g.PointLen(), g.ScalarLen())
+
+	points := make([]kyber.Point, 0)
+	ptmp := g.Point()
+	stmp := g.Scalar()
+	pzero := g.Point().Null()
+	szero := g.Scalar().Zero()
+	sone := g.Scalar().One()
+
+	// Do a simple Diffie-Hellman test
+	s1 := g.Scalar().Pick(rand)
+	s2 := g.Scalar().Pick(rand)
+	if s1.Equal(szero) {
+		t.Fatalf("first secret is scalar zero %v", s1)
+	}
+	if s2.Equal(szero) {
+		t.Fatalf("second secret is scalar zero %v", s2)
+	}
+	if s1.Equal(s2) {
+		t.Fatalf("not getting unique secrets: picked %s twice", s1)
+	}
+
+	gen := g.Point().Base()
+	points = append(points, gen)
+
+	// Sanity-check relationship between addition and multiplication
+	p1 := g.Point().Add(gen, gen)
+	p2 := g.Point().Mul(stmp.SetInt64(2), nil)
+	if !p1.Equal(p2) {
+		t.Fatalf("multiply by two doesn't work: %v == %v (+) %[2]v != %[2]v (x) 2 == %v", p1, gen, p2)
+	}
+	p1.Add(p1, p1)
+	p2.Mul(stmp.SetInt64(4), nil)
+	if !p1.Equal(p2) {
+		t.Fatalf("multiply by four doesn't work: %v (+) %[1]v != %v (x) 4 == %v",
+			g.Point().Add(gen, gen), gen, p2)
+	}
+	points = append(points, p1)
+
+	// Find out if this curve has a prime order:
+	// if the curve does not offer a method IsPrimeOrder,
+	// then assume that it is.
+	type canCheckPrimeOrder interface {
+		IsPrimeOrder() bool
+	}
+	primeOrder := true
+	if gpo, ok := g.(canCheckPrimeOrder); ok {
+		primeOrder = gpo.IsPrimeOrder()
+	}
+
+	// Verify additive and multiplicative identities of the generator.
+	ptmp.Mul(stmp.SetInt64(-1), nil).Add(ptmp, gen)
+	if !ptmp.Equal(pzero) {
+		t.Fatalf("generator additive identity doesn't work: (scalar -1 %v) %v (x) -1 (+) %v = %v != %v the group point identity",
+			stmp.SetInt64(-1), ptmp.Mul(stmp.SetInt64(-1), nil), gen, ptmp.Mul(stmp.SetInt64(-1), nil).Add(ptmp, gen), pzero)
+	}
+	// secret.Inv works only in prime-order groups
+	if primeOrder {
+		ptmp.Mul(stmp.SetInt64(2), nil).Mul(stmp.Inv(stmp), ptmp)
+		if !ptmp.Equal(gen) {
+			t.Fatalf("generator multiplicative identity doesn't work:\n%v (x) %v = %v\n%[3]v (x) %v = %v",
+				ptmp.Base().String(), stmp.SetInt64(2).String(),
+				ptmp.Mul(stmp.SetInt64(2), nil).String(),
+				stmp.Inv(stmp).String(),
+				ptmp.Mul(stmp.SetInt64(2), nil).Mul(stmp.Inv(stmp), ptmp).String())
+		}
+	}
+
+	p1.Mul(s1, gen)
+	p2.Mul(s2, gen)
+	if p1.Equal(p2) {
+		t.Fatalf("encryption isn't producing unique points: %v (x) %v == %v (x) %[2]v == %[4]v", s1, gen, s2, p1)
+	}
+	points = append(points, p1)
+
+	dh1 := g.Point().Mul(s2, p1)
+	dh2 := g.Point().Mul(s1, p2)
+	if !dh1.Equal(dh2) {
+		t.Fatalf("Diffie-Hellman didn't work: %v == %v (x) %v != %v (x) %v == %v", dh1, s2, p1, s1, p2, dh2)
+	}
+	points = append(points, dh1)
+	//t.Logf("shared secret = %v", dh1)
+
+	// Test secret inverse to get from dh1 back to p1
+	if primeOrder {
+		ptmp.Mul(g.Scalar().Inv(s2), dh1)
+		if !ptmp.Equal(p1) {
+			t.Fatalf("Scalar inverse didn't work: %v != (-)%v (x) %v == %v", p1, s2, dh1, ptmp)
+		}
+	}
+
+	// Zero and One identity secrets
+	if !ptmp.Mul(szero, dh1).Equal(pzero) {
+		t.Fatalf("Encryption with secret=0 didn't work: %v (x) %v == %v != %v", szero, dh1, ptmp, pzero)
+	}
+	if !ptmp.Mul(sone, dh1).Equal(dh1) {
+		t.Fatalf("Encryption with secret=1 didn't work: %v (x) %v == %v != %[2]v", sone, dh1, ptmp)
+	}
+
+	// Additive homomorphic identities
+	ptmp.Add(p1, p2)
+	stmp.Add(s1, s2)
+	pt2 := g.Point().Mul(stmp, gen)
+	if !pt2.Equal(ptmp) {
+		t.Fatalf("Additive homomorphism doesn't work: %v + %v == %v, %[3]v (x) %v == %v != %v == %v (+) %v",
+			s1, s2, stmp, gen, pt2, ptmp, p1, p2)
+	}
+	ptmp.Sub(p1, p2)
+	stmp.Sub(s1, s2)
+	pt2.Mul(stmp, gen)
+	if !pt2.Equal(ptmp) {
+		t.Fatalf("Additive homomorphism doesn't work: %v - %v == %v, %[3]v (x) %v == %v != %v == %v (-) %v",
+			s1, s2, stmp, gen, pt2, ptmp, p1, p2)
+	}
+	st2 := g.Scalar().Neg(s2)
+	st2.Add(s1, st2)
+	if !stmp.Equal(st2) {
+		t.Fatalf("Scalar.Neg doesn't work: -%v == %v, %[2]v + %v == %v != %v",
+			s2, g.Scalar().Neg(s2), s1, st2, stmp)
+	}
+	pt2.Neg(p2).Add(pt2, p1)
+	if !pt2.Equal(ptmp) {
+		t.Fatalf("Point.Neg doesn't work: (-)%v == %v, %[2]v (+) %v == %v != %v",
+			p2, g.Point().Neg(p2), p1, pt2, ptmp)
+	}
+
+	// Multiplicative homomorphic identities
+	stmp.Mul(s1, s2)
+	if !ptmp.Mul(stmp, gen).Equal(dh1) {
+		t.Fatalf("Multiplicative homomorphism doesn't work: %v * %v == %v, %[2]v (x) %v == %v != %v",
+			s1, s2, stmp, gen, ptmp, dh1)
+	}
+	if primeOrder {
+		st2.Inv(s2)
+		st2.Mul(st2, stmp)
+		if !st2.Equal(s1) {
+			t.Fatalf("Scalar division doesn't work: %v^-1 * %v == %v * %[2]v == %[4]v != %v",
+				s2, stmp, g.Scalar().Inv(s2), st2, s1)
+		}
+		st2.Div(stmp, s2)
+		if !st2.Equal(s1) {
+			t.Fatalf("Scalar division doesn't work: %v / %v == %v != %v",
+				stmp, s2, st2, s1)
+		}
+	}
+
+	pick := func(rand cipher.Stream) (p kyber.Point) {
+		defer func() {
+		}()
+		p = g.Point().Pick(rand)
+		return
+	}
+
+	// Test randomly picked points
+	last := gen
+	for i := 0; i < 5; i++ {
+		// TODO fork kyber and make that an interface
+		rgen := pick(rand)
+		if rgen.Equal(last) {
+			t.Fatalf("Pick() not producing unique points: got %v twice", rgen)
+		}
+		last = rgen
+
+		ptmp.Mul(stmp.SetInt64(-1), rgen).Add(ptmp, rgen)
+		if !ptmp.Equal(pzero) {
+			t.Fatalf("random generator fails additive identity: %v (x) %v == %v, %v (+) %[3]v == %[5]v != %v",
+				g.Scalar().SetInt64(-1), rgen, g.Point().Mul(g.Scalar().SetInt64(-1), rgen),
+				rgen, g.Point().Mul(g.Scalar().SetInt64(-1), rgen), pzero)
+		}
+		if primeOrder {
+			ptmp.Mul(stmp.SetInt64(2), rgen).Mul(stmp.Inv(stmp), ptmp)
+			if !ptmp.Equal(rgen) {
+				t.Fatalf("random generator fails multiplicative identity: %v (x) (2 (x) %v) == %v != %[2]v",
+					stmp, rgen, ptmp)
+			}
+		}
+		points = append(points, rgen)
+	}
+
+	// Test encoding and decoding
+	buf := new(bytes.Buffer)
+	for i := 0; i < 5; i++ {
+		buf.Reset()
+		s := g.Scalar().Pick(rand)
+		if _, err := s.MarshalTo(buf); err != nil {
+			t.Fatalf("encoding of secret fails: " + err.Error())
+		}
+		if _, err := stmp.UnmarshalFrom(buf); err != nil {
+			t.Fatalf("decoding of secret fails: " + err.Error())
+		}
+		if !stmp.Equal(s) {
+			t.Fatalf("decoding produces different secret than encoded")
+		}
+
+		buf.Reset()
+		p := pick(rand)
+		if _, err := p.MarshalTo(buf); err != nil {
+			t.Fatalf("encoding of point fails: " + err.Error())
+		}
+		if _, err := ptmp.UnmarshalFrom(buf); err != nil {
+			t.Fatalf("decoding of point fails: " + err.Error())
+		}
+
+		if !ptmp.Equal(p) {
+			t.Fatalf("decoding produces different point than encoded")
+		}
+	}
+
+	// Test that we can marshal/ unmarshal null point
+	pzero = g.Point().Null()
+	b, _ := pzero.MarshalBinary()
+	repzero := g.Point()
+	err := repzero.UnmarshalBinary(b)
+	if err != nil {
+		t.Fatalf("Could not unmarshall binary %v: %v", b, err)
+	}
+
+	return points
+}
+
+// GroupTest applies a generic set of validation tests to a cryptographic Group.
+func GroupTest(t *testing.T, g kyber.Group) {
+	testGroup(t, g, random.New())
+}
+
+func TestG1(t *testing.T) {
+	GroupTest(t, NewGroupG1())
+}
+
+func TestG2(t *testing.T) {
+	GroupTest(t, NewGroupG2())
+}
+
+func TestPairingG2(t *testing.T) {
+	s := NewSuite()
+	a := s.G1().Scalar().Pick(s.RandomStream())
+	b := s.G2().Scalar().Pick(s.RandomStream())
+	aG := s.G1().Point().Mul(a, nil)
+	bH := s.G2().Point().Mul(b, nil)
+	ab := s.G1().Scalar().Mul(a, b)
+	abG := s.G1().Point().Mul(ab, nil)
+	// e(aG, bG) = e(G,H)^(ab)
+	p1 := s.Pair(aG, bH)
+	// e((ab)G,H) = e(G,H)^(ab)
+	p2 := s.Pair(abG, s.G2().Point().Base())
+	require.True(t, p1.Equal(p2))
+	require.True(t, s.ValidatePairing(aG, bH, abG.Clone(), s.G2().Point().Base()))
+
+	pRandom := s.Pair(aG, s.G2().Point().Pick(s.RandomStream()))
+	require.False(t, p1.Equal(pRandom))
+	pRandom = s.Pair(s.G1().Point().Pick(s.RandomStream()), bH)
+	require.False(t, p1.Equal(pRandom))
+}
+
+func BenchmarkPairingSeparate(bb *testing.B) {
+	s := NewSuite()
+	a := s.G1().Scalar().Pick(s.RandomStream())
+	b := s.G2().Scalar().Pick(s.RandomStream())
+	aG := s.G1().Point().Mul(a, nil)
+	bH := s.G2().Point().Mul(b, nil)
+	ab := s.G1().Scalar().Mul(a, b)
+	abG := s.G1().Point().Mul(ab, nil)
+	bb.ResetTimer()
+	for i := 0; i < bb.N; i++ {
+
+		// e(aG, bG) = e(G,H)^(ab)
+		p1 := s.Pair(aG, bH)
+		// e((ab)G,H) = e(G,H)^(ab)
+		p2 := s.Pair(abG, s.G2().Point().Base())
+		if !p1.Equal(p2) {
+			panic("aie")
+		}
+	}
+}
+
+func BenchmarkPairingInv(bb *testing.B) {
+	s := NewSuite()
+	a := s.G1().Scalar().Pick(s.RandomStream())
+	b := s.G2().Scalar().Pick(s.RandomStream())
+	aG := s.G1().Point().Mul(a, nil)
+	bH := s.G2().Point().Mul(b, nil)
+	ab := s.G1().Scalar().Mul(a, b)
+	abG := s.G1().Point().Mul(ab, nil)
+	bb.ResetTimer()
+	for i := 0; i < bb.N; i++ {
+		if !s.ValidatePairing(aG, bH, abG.Clone(), s.G2().Point().Base()) {
+			panic("aie")
+		}
+	}
+}
+
+func TestIsValidGroup(t *testing.T) {
+	suite := NewSuite()
+	p1 := suite.G1().Point().Pick(random.New())
+	p2 := suite.G1().Point().Pick(random.New())
+
+	require.True(t, p1.(GroupChecker).IsInCorrectGroup())
+	require.True(t, p2.(GroupChecker).IsInCorrectGroup())
+}
+
+var suite = NewSuite()
+
+func NewElement() kyber.Scalar {
+	return suite.G1().Scalar()
+}
+func NewG1() kyber.Point {
+	return suite.G1().Point().Base()
+}
+func NewG2() kyber.Point {
+	return suite.G2().Point().Base()
+}
+func Pair(a, b kyber.Point) kyber.Point {
+	return suite.Pair(a, b)
+}
+func TestBasicPairing(t *testing.T) {
+
+	// we test a * b = c + d
+	a := NewElement().Pick(random.New())
+	b := NewElement().Pick(random.New())
+	c := NewElement().Pick(random.New())
+	d := NewElement().Sub(NewElement().Mul(a, b), c)
+
+	// check in the clear
+	ab := NewElement().Mul(a, b)
+	cd := NewElement().Add(c, d)
+	require.True(t, ab.Equal(cd))
+
+	// check in the exponent now with the following
+	// e(aG1,bG2) = e(cG1,G2) * e(G1,dG2) <=>
+	// e(G1,G2)^(a*b) = e(G1,G2)^c * e(G1,G2)^d
+	// e(G1,G2)^(a*b) = e(G1,G2)^(c + d)
+	aG := NewG1().Mul(a, nil)
+	bG := NewG2().Mul(b, nil)
+	left := Pair(aG, bG)
+
+	cG := NewG1().Mul(c, nil)
+	right1 := Pair(cG, NewG2())
+	dG := NewG2().Mul(d, nil)
+	right2 := Pair(NewG1(), dG)
+	right := suite.GT().Point().Add(right1, right2)
+
+	require.True(t, left.Equal(right))
+}

--- a/pairing/bls12381/suite_test.go
+++ b/pairing/bls12381/suite_test.go
@@ -246,11 +246,11 @@ func GroupTest(t *testing.T, g kyber.Group) {
 }
 
 func TestG1(t *testing.T) {
-	GroupTest(t, NewGroupG1())
+	GroupTest(t, newGroupG1())
 }
 
 func TestG2(t *testing.T) {
-	GroupTest(t, NewGroupG2())
+	GroupTest(t, newGroupG2())
 }
 
 func TestPairingG2(t *testing.T) {

--- a/sign/bls/bls_test.go
+++ b/sign/bls/bls_test.go
@@ -22,7 +22,7 @@ func TestBn256(t *testing.T) {
 	testBLSFailAggregatedKey(t, suite)
 	testBLSBatchVerify(t, suite)
 	testBLSFailBatchVerify(t, suite)
-	testBinaryMarshalAfterAggregation_issue400(t, suite)
+	testBinaryMarshalAfterAggregationIssue400(t, suite)
 }
 
 func TestBLS12381(t *testing.T) {
@@ -35,7 +35,7 @@ func TestBLS12381(t *testing.T) {
 	testBLSFailAggregatedKey(t, suite)
 	testBLSBatchVerify(t, suite)
 	testBLSFailBatchVerify(t, suite)
-	testBinaryMarshalAfterAggregation_issue400(t, suite)
+	testBinaryMarshalAfterAggregationIssue400(t, suite)
 }
 
 func testBLS(t *testing.T, suite pairing.Suite) {
@@ -167,7 +167,7 @@ func testBLSFailBatchVerify(t *testing.T, suite pairing.Suite) {
 	})
 
 }
-func testBinaryMarshalAfterAggregation_issue400(t *testing.T, suite pairing.Suite) {
+func testBinaryMarshalAfterAggregationIssue400(t *testing.T, suite pairing.Suite) {
 	_, public1 := NewKeyPair(suite, random.New())
 	_, public2 := NewKeyPair(suite, random.New())
 

--- a/sign/tbls/tbls_test.go
+++ b/sign/tbls/tbls_test.go
@@ -4,15 +4,26 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	"go.dedis.ch/kyber/v3/pairing"
+	"go.dedis.ch/kyber/v3/pairing/bls12381"
 	"go.dedis.ch/kyber/v3/pairing/bn256"
 	"go.dedis.ch/kyber/v3/share"
 	"go.dedis.ch/kyber/v3/sign/bls"
 )
 
-func TestTBLS(test *testing.T) {
+func TestBn256(test *testing.T) {
+	suite := bn256.NewSuite()
+	testTBLS(test, suite)
+}
+
+func TestBLS12381(test *testing.T) {
+	suite := bls12381.NewSuite()
+	testTBLS(test, suite)
+}
+
+func testTBLS(test *testing.T, suite pairing.Suite) {
 	var err error
 	msg := []byte("Hello threshold Boneh-Lynn-Shacham")
-	suite := bn256.NewSuite()
 	n := 10
 	t := n/2 + 1
 	secret := suite.G1().Scalar().Pick(suite.RandomStream())


### PR DESCRIPTION
1. The curve code is from https://github.com/kilic/bls12-381
2. This is based on the work from https://github.com/drand/kyber-bls12381/ but modified to make the coding style consistent between bn256 and bls12381. 
3. Tests in sign/bls and sign/tbls are updated to support testing both bn256 and bls12381
4. This PR is related to issue https://github.com/dedis/kyber/issues/402