### PR TITLE
Fix a bug in method: String() of PriShare

### DIFF
--- a/share/poly.go
+++ b/share/poly.go
@@ -40,7 +40,7 @@ func (p *PriShare) Hash(s kyber.HashFactory) []byte {
 }
 
 func (p *PriShare) String() string {
-	return fmt.Sprintf("{%d:%p}", p.I, p.V)
+	return fmt.Sprintf("{%d:%v}", p.I, p.V)
 }
 
 // PriPoly represents a secret sharing polynomial.


### PR DESCRIPTION
It is weird that method `String()` of `PriShare` returns the pointer to V currently. 
Maybe, it would be better to reflect the data contents. Thus, we can compare if two variables of PriShare are equal, by simply comparing the results of `String()` method.