### PR TITLE
Bumping go version for linter to 1.20

### DIFF
--- a/.github/workflows/go_lint.yml
+++ b/.github/workflows/go_lint.yml
@@ -11,10 +11,10 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - name: Set up Go ^1.13 
+      - name: Set up Go ^1.20
         uses: actions/setup-go@v3
         with:
-          go-version: ^1.13
+          go-version: ^1.20
 
       - name: Check out code into the Go module directory
         uses: actions/checkout@v3


### PR DESCRIPTION
There seems to be an error when linting, due to an old go-version.