### PR TITLE
pairing: Add support for BLS12381 pairings using CIRCL library

### DIFF
--- a/examples/bn256_enc_test.go
+++ b/examples/bn256_enc_test.go
@@ -5,6 +5,7 @@ import (
 
 	"go.dedis.ch/kyber/v3"
 	"go.dedis.ch/kyber/v3/pairing"
+	"go.dedis.ch/kyber/v3/pairing/bn256"
 	"go.dedis.ch/kyber/v3/util/random"
 )
 
@@ -60,7 +61,7 @@ see for example anon.Encrypt, which encrypts a message for
 one of several possible receivers forming an explicit anonymity set.
 */
 func Example_elGamalEncryption_bn256() {
-	suite := pairing.NewSuiteBn256()
+	suite := bn256.NewSuiteBn256()
 
 	// Create a public/private keypair
 	a := suite.G1().Scalar().Pick(suite.RandomStream()) // Alice's private key

--- a/go.mod
+++ b/go.mod
@@ -1,11 +1,12 @@
 module go.dedis.ch/kyber/v3
 
 require (
+	github.com/cloudflare/circl v1.3.2
 	github.com/stretchr/testify v1.3.0
 	go.dedis.ch/fixbuf v1.0.3
 	go.dedis.ch/protobuf v1.0.11
-	golang.org/x/crypto v0.0.0-20190123085648-057139ce5d2b
-	golang.org/x/sys v0.0.0-20190124100055-b90733256f2e
+	golang.org/x/crypto v0.0.0-20220722155217-630584e8d5aa
+	golang.org/x/sys v0.0.0-20220811171246-fbc7d0a398ab
 )
 
 go 1.13

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,6 @@
+github.com/bwesterb/go-ristretto v1.2.2/go.mod h1:fUIoIZaG73pV5biE2Blr2xEzDoMj7NFEuV9ekS419A0=
+github.com/cloudflare/circl v1.3.2 h1:VWp8dY3yH69fdM7lM6A1+NhhVoDu9vqK0jOgmkQHFWk=
+github.com/cloudflare/circl v1.3.2/go.mod h1:+CauBF6R70Jqcyl8N2hC8pAXYbWkGIezuSbuGLtRhnw=
 github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
@@ -13,7 +16,16 @@ go.dedis.ch/protobuf v1.0.5/go.mod h1:eIV4wicvi6JK0q/QnfIEGeSFNG0ZeB24kzut5+HaRL
 go.dedis.ch/protobuf v1.0.7/go.mod h1:pv5ysfkDX/EawiPqcW3ikOxsL5t+BqnV6xHSmE79KI4=
 go.dedis.ch/protobuf v1.0.11 h1:FTYVIEzY/bfl37lu3pR4lIj+F9Vp1jE8oh91VmxKgLo=
 go.dedis.ch/protobuf v1.0.11/go.mod h1:97QR256dnkimeNdfmURz0wAMNVbd1VmLXhG1CrTYrJ4=
-golang.org/x/crypto v0.0.0-20190123085648-057139ce5d2b h1:Elez2XeF2p9uyVj0yEUDqQ56NFcDtcBNkYP7yv8YbUE=
 golang.org/x/crypto v0.0.0-20190123085648-057139ce5d2b/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
-golang.org/x/sys v0.0.0-20190124100055-b90733256f2e h1:3GIlrlVLfkoipSReOMNAgApI0ajnalyLa/EZHHca/XI=
+golang.org/x/crypto v0.0.0-20220722155217-630584e8d5aa h1:zuSxTR4o9y82ebqCUJYNGJbGPo6sKVl54f/TVDObg1c=
+golang.org/x/crypto v0.0.0-20220722155217-630584e8d5aa/go.mod h1:IxCIyHEi3zRg3s0A5j5BB6A9Jmi73HwBIUl50j+osU4=
+golang.org/x/net v0.0.0-20211112202133-69e39bad7dc2/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/sys v0.0.0-20190124100055-b90733256f2e/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
+golang.org/x/sys v0.0.0-20201119102817-f84b799fce68/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20210423082822-04245dca01da/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20220811171246-fbc7d0a398ab h1:2QkjZIsXupsJbJIdSjjUOgWK3aEtzyuh2mPt3l/CkeU=
+golang.org/x/sys v0.0.0-20220811171246-fbc7d0a398ab/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
+golang.org/x/text v0.3.6/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
+golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=

--- a/pairing/bls12381/adapter.go
+++ b/pairing/bls12381/adapter.go
@@ -1,0 +1,46 @@
+package bls12381
+
+import "go.dedis.ch/kyber/v3"
+
+// SuiteBLS12381 is an adapter that implements the suites.Suite interface so that
+// bls12381 can be used as a common suite to generate key pairs for instance but
+// still preserves the properties of the pairing (e.g. the Pair function).
+//
+// It's important to note that the Point function will generate a point
+// compatible with public keys only (group G2) where the signature must be
+// used as a point from the group G1.
+type SuiteBLS12381 struct {
+	Suite
+	kyber.Group
+}
+
+// NewSuiteBLS12381 makes a new BN256 suite
+func NewSuiteBLS12381() *SuiteBLS12381 {
+	return &SuiteBLS12381{}
+}
+
+// Point generates a point from the G2 group that can only be used
+// for public keys
+func (s *SuiteBLS12381) Point() kyber.Point {
+	return s.G2().Point()
+}
+
+// PointLen returns the length of a G2 point
+func (s *SuiteBLS12381) PointLen() int {
+	return s.G2().PointLen()
+}
+
+// Scalar generates a scalar
+func (s *SuiteBLS12381) Scalar() kyber.Scalar {
+	return s.G1().Scalar()
+}
+
+// ScalarLen returns the lenght of a scalar
+func (s *SuiteBLS12381) ScalarLen() int {
+	return s.G1().ScalarLen()
+}
+
+// String returns the name of the suite
+func (s *SuiteBLS12381) String() string {
+	return "bls12381.adapter"
+}

--- a/pairing/bls12381/adapter_test.go
+++ b/pairing/bls12381/adapter_test.go
@@ -1,0 +1,28 @@
+package bls12381
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.dedis.ch/kyber/v3/util/key"
+)
+
+func TestAdapter_SuiteBLS12381(t *testing.T) {
+	suite := NewSuiteBLS12381()
+
+	pair := key.NewKeyPair(suite)
+	pubkey, err := pair.Public.MarshalBinary()
+	require.Nil(t, err)
+	privkey, err := pair.Private.MarshalBinary()
+	require.Nil(t, err)
+
+	pubhex := suite.Point()
+	err = pubhex.UnmarshalBinary(pubkey)
+	require.Nil(t, err)
+
+	privhex := suite.Scalar()
+	err = privhex.UnmarshalBinary(privkey)
+	require.Nil(t, err)
+
+	require.Equal(t, "bls12381.adapter", suite.String())
+}

--- a/pairing/bls12381/g1.go
+++ b/pairing/bls12381/g1.go
@@ -1,0 +1,94 @@
+package bls12381
+
+import (
+	"crypto/cipher"
+	"io"
+
+	circl "github.com/cloudflare/circl/ecc/bls12381"
+	"go.dedis.ch/kyber/v3"
+)
+
+var _ kyber.Point = &G1Elt{}
+
+type G1Elt struct{ inner circl.G1 }
+
+func (p *G1Elt) MarshalBinary() (data []byte, err error) { return p.inner.BytesCompressed(), nil }
+
+func (p *G1Elt) UnmarshalBinary(data []byte) error { return p.inner.SetBytes(data) }
+
+func (p *G1Elt) String() string { return p.inner.String() }
+
+func (p *G1Elt) MarshalSize() int { return circl.G1SizeCompressed }
+
+func (p *G1Elt) MarshalTo(w io.Writer) (int, error) {
+	buf, err := p.MarshalBinary()
+	if err != nil {
+		return 0, err
+	}
+	return w.Write(buf)
+}
+
+func (p *G1Elt) UnmarshalFrom(r io.Reader) (int, error) {
+	buf := make([]byte, p.MarshalSize())
+	n, err := io.ReadFull(r, buf)
+	if err != nil {
+		return n, err
+	}
+	return n, p.UnmarshalBinary(buf)
+}
+
+func (p *G1Elt) Equal(p2 kyber.Point) bool { x := p2.(*G1Elt); return p.inner.IsEqual(&x.inner) }
+
+func (p *G1Elt) Null() kyber.Point { p.inner.SetIdentity(); return p }
+
+func (p *G1Elt) Base() kyber.Point { p.inner = *circl.G1Generator(); return p }
+
+func (p *G1Elt) Pick(rand cipher.Stream) kyber.Point {
+	var buf [32]byte
+	rand.XORKeyStream(buf[:], buf[:])
+	p.inner.Hash(buf[:], nil)
+	return p
+}
+
+func (p *G1Elt) Set(p2 kyber.Point) kyber.Point { p.inner = p2.(*G1Elt).inner; return p }
+
+func (p *G1Elt) Clone() kyber.Point { return new(G1Elt).Set(p) }
+
+func (p *G1Elt) EmbedLen() int {
+	panic("bls12-381: unsupported operation")
+}
+
+func (p *G1Elt) Embed(data []byte, r cipher.Stream) kyber.Point {
+	panic("bls12-381: unsupported operation")
+}
+
+func (p *G1Elt) Data() ([]byte, error) {
+	panic("bls12-381: unsupported operation")
+}
+
+func (p *G1Elt) Add(a, b kyber.Point) kyber.Point {
+	aa, bb := a.(*G1Elt), b.(*G1Elt)
+	p.inner.Add(&aa.inner, &bb.inner)
+	return p
+}
+
+func (p *G1Elt) Sub(a, b kyber.Point) kyber.Point { return p.Add(a, new(G1Elt).Neg(b)) }
+
+func (p *G1Elt) Neg(a kyber.Point) kyber.Point {
+	p.Set(a)
+	p.inner.Neg()
+	return p
+}
+
+func (p *G1Elt) Mul(s kyber.Scalar, q kyber.Point) kyber.Point {
+	if q == nil {
+		q = new(G1Elt).Base()
+	}
+	ss, qq := s.(*Scalar), q.(*G1Elt)
+	p.inner.ScalarMult(&ss.inner, &qq.inner)
+	return p
+}
+
+func (p *G1Elt) IsInCorrectGroup() bool { return p.inner.IsOnG1() }
+
+func (p *G1Elt) Hash(msg []byte) kyber.Point { p.inner.Hash(msg, nil); return p }

--- a/pairing/bls12381/g2.go
+++ b/pairing/bls12381/g2.go
@@ -1,0 +1,94 @@
+package bls12381
+
+import (
+	"crypto/cipher"
+	"io"
+
+	circl "github.com/cloudflare/circl/ecc/bls12381"
+	"go.dedis.ch/kyber/v3"
+)
+
+var _ kyber.Point = &G2Elt{}
+
+type G2Elt struct{ inner circl.G2 }
+
+func (p *G2Elt) MarshalBinary() (data []byte, err error) { return p.inner.BytesCompressed(), nil }
+
+func (p *G2Elt) UnmarshalBinary(data []byte) error { return p.inner.SetBytes(data) }
+
+func (p *G2Elt) String() string { return p.inner.String() }
+
+func (p *G2Elt) MarshalSize() int { return circl.G2SizeCompressed }
+
+func (p *G2Elt) MarshalTo(w io.Writer) (int, error) {
+	buf, err := p.MarshalBinary()
+	if err != nil {
+		return 0, err
+	}
+	return w.Write(buf)
+}
+
+func (p *G2Elt) UnmarshalFrom(r io.Reader) (int, error) {
+	buf := make([]byte, p.MarshalSize())
+	n, err := io.ReadFull(r, buf)
+	if err != nil {
+		return n, err
+	}
+	return n, p.UnmarshalBinary(buf)
+}
+
+func (p *G2Elt) Equal(p2 kyber.Point) bool { x := p2.(*G2Elt); return p.inner.IsEqual(&x.inner) }
+
+func (p *G2Elt) Null() kyber.Point { p.inner.SetIdentity(); return p }
+
+func (p *G2Elt) Base() kyber.Point { p.inner = *circl.G2Generator(); return p }
+
+func (p *G2Elt) Pick(rand cipher.Stream) kyber.Point {
+	var buf [32]byte
+	rand.XORKeyStream(buf[:], buf[:])
+	p.inner.Hash(buf[:], nil)
+	return p
+}
+
+func (p *G2Elt) Set(p2 kyber.Point) kyber.Point { p.inner = p2.(*G2Elt).inner; return p }
+
+func (p *G2Elt) Clone() kyber.Point { return new(G2Elt).Set(p) }
+
+func (p *G2Elt) EmbedLen() int {
+	panic("bls12-381: unsupported operation")
+}
+
+func (p *G2Elt) Embed(data []byte, r cipher.Stream) kyber.Point {
+	panic("bls12-381: unsupported operation")
+}
+
+func (p *G2Elt) Data() ([]byte, error) {
+	panic("bls12-381: unsupported operation")
+}
+
+func (p *G2Elt) Add(a, b kyber.Point) kyber.Point {
+	aa, bb := a.(*G2Elt), b.(*G2Elt)
+	p.inner.Add(&aa.inner, &bb.inner)
+	return p
+}
+
+func (p *G2Elt) Sub(a, b kyber.Point) kyber.Point { return p.Add(a, new(G2Elt).Neg(b)) }
+
+func (p *G2Elt) Neg(a kyber.Point) kyber.Point {
+	p.Set(a)
+	p.inner.Neg()
+	return p
+}
+
+func (p *G2Elt) Mul(s kyber.Scalar, q kyber.Point) kyber.Point {
+	if q == nil {
+		q = new(G2Elt).Base()
+	}
+	ss, qq := s.(*Scalar), q.(*G2Elt)
+	p.inner.ScalarMult(&ss.inner, &qq.inner)
+	return p
+}
+
+func (p *G2Elt) IsInCorrectGroup() bool { return p.inner.IsOnG2() }
+
+func (p *G2Elt) Hash(msg []byte) kyber.Point { p.inner.Hash(msg, nil); return p }

--- a/pairing/bls12381/group.go
+++ b/pairing/bls12381/group.go
@@ -1,0 +1,23 @@
+package bls12381
+
+import (
+	circl "github.com/cloudflare/circl/ecc/bls12381"
+	"go.dedis.ch/kyber/v3"
+)
+
+var (
+	G1 kyber.Group = &groupBls{name: "bls12-381.G1", newPoint: func() kyber.Point { return new(G1Elt).Null() }}
+	G2 kyber.Group = &groupBls{name: "bls12-381.G2", newPoint: func() kyber.Point { return new(G2Elt).Null() }}
+	GT kyber.Group = &groupBls{name: "bls12-381.GT", newPoint: func() kyber.Point { return new(GTElt).Null() }}
+)
+
+type groupBls struct {
+	name     string
+	newPoint func() kyber.Point
+}
+
+func (g groupBls) String() string       { return g.name }
+func (g groupBls) ScalarLen() int       { return circl.ScalarSize }
+func (g groupBls) Scalar() kyber.Scalar { return new(Scalar).SetInt64(0) }
+func (g groupBls) PointLen() int        { return g.newPoint().MarshalSize() }
+func (g groupBls) Point() kyber.Point   { return g.newPoint() }

--- a/pairing/bls12381/gt.go
+++ b/pairing/bls12381/gt.go
@@ -1,0 +1,92 @@
+package bls12381
+
+import (
+	"crypto/cipher"
+	"io"
+
+	circl "github.com/cloudflare/circl/ecc/bls12381"
+	"go.dedis.ch/kyber/v3"
+)
+
+var gtBase *circl.Gt
+
+func init() {
+	gtBase = circl.Pair(circl.G1Generator(), circl.G2Generator())
+}
+
+var _ kyber.Point = &GTElt{}
+
+type GTElt struct{ inner circl.Gt }
+
+func (p *GTElt) MarshalBinary() (data []byte, err error) { return p.inner.MarshalBinary() }
+
+func (p *GTElt) UnmarshalBinary(data []byte) error { return p.inner.UnmarshalBinary(data) }
+
+func (p *GTElt) String() string { return p.inner.String() }
+
+func (p *GTElt) MarshalSize() int { return circl.GtSize }
+
+func (p *GTElt) MarshalTo(w io.Writer) (int, error) {
+	buf, err := p.MarshalBinary()
+	if err != nil {
+		return 0, err
+	}
+	return w.Write(buf)
+}
+
+func (p *GTElt) UnmarshalFrom(r io.Reader) (int, error) {
+	buf := make([]byte, p.MarshalSize())
+	n, err := io.ReadFull(r, buf)
+	if err != nil {
+		return n, err
+	}
+	return n, p.UnmarshalBinary(buf)
+}
+
+func (p *GTElt) Equal(p2 kyber.Point) bool { x := p2.(*GTElt); return p.inner.IsEqual(&x.inner) }
+
+func (p *GTElt) Null() kyber.Point { p.inner.SetIdentity(); return p }
+
+func (p *GTElt) Base() kyber.Point { p.inner = *gtBase; return p }
+
+func (p *GTElt) Pick(rand cipher.Stream) kyber.Point {
+	panic("bls12-381: unsupported operation")
+}
+
+func (p *GTElt) Set(p2 kyber.Point) kyber.Point { p.inner = p2.(*GTElt).inner; return p }
+
+func (p *GTElt) Clone() kyber.Point { return new(GTElt).Set(p) }
+
+func (p *GTElt) EmbedLen() int {
+	panic("bls12-381: unsupported operation")
+}
+
+func (p *GTElt) Embed(data []byte, r cipher.Stream) kyber.Point {
+	panic("bls12-381: unsupported operation")
+}
+
+func (p *GTElt) Data() ([]byte, error) {
+	panic("bls12-381: unsupported operation")
+}
+
+func (p *GTElt) Add(a, b kyber.Point) kyber.Point {
+	aa, bb := a.(*GTElt), b.(*GTElt)
+	p.inner.Mul(&aa.inner, &bb.inner)
+	return p
+}
+
+func (p *GTElt) Sub(a, b kyber.Point) kyber.Point {
+	return p.Add(a, new(GTElt).Neg(b))
+}
+
+func (p *GTElt) Neg(a kyber.Point) kyber.Point {
+	aa := a.(*GTElt)
+	p.inner.Inv(&aa.inner)
+	return p
+}
+
+func (p *GTElt) Mul(s kyber.Scalar, q kyber.Point) kyber.Point {
+	qq, ss := q.(*GTElt), s.(*Scalar)
+	p.inner.Exp(&qq.inner, &ss.inner)
+	return p
+}

--- a/pairing/bls12381/scalar.go
+++ b/pairing/bls12381/scalar.go
@@ -1,0 +1,117 @@
+package bls12381
+
+import (
+	"crypto/cipher"
+	"io"
+
+	circl "github.com/cloudflare/circl/ecc/bls12381"
+	"go.dedis.ch/kyber/v3"
+)
+
+var _ kyber.Scalar = &Scalar{}
+
+type Scalar struct{ inner circl.Scalar }
+
+func (s *Scalar) MarshalBinary() (data []byte, err error) { return s.inner.MarshalBinary() }
+
+func (s *Scalar) UnmarshalBinary(data []byte) error { return s.inner.UnmarshalBinary(data) }
+
+func (s *Scalar) String() string { return s.inner.String() }
+
+func (s *Scalar) MarshalSize() int { return circl.ScalarSize }
+
+func (s *Scalar) MarshalTo(w io.Writer) (int, error) {
+	buf, err := s.inner.MarshalBinary()
+	if err != nil {
+		return 0, err
+	}
+	return w.Write(buf)
+}
+
+func (s *Scalar) UnmarshalFrom(r io.Reader) (int, error) {
+	buf := make([]byte, s.MarshalSize())
+	n, err := io.ReadFull(r, buf)
+	if err != nil {
+		return n, err
+	}
+	return n, s.inner.UnmarshalBinary(buf)
+}
+
+func (s *Scalar) Equal(s2 kyber.Scalar) bool {
+	x := s2.(*Scalar)
+	return s.inner.IsEqual(&x.inner) == 1
+}
+
+func (s *Scalar) Set(a kyber.Scalar) kyber.Scalar {
+	aa := a.(*Scalar)
+	s.inner.Set(&aa.inner)
+	return s
+}
+
+func (s *Scalar) Clone() kyber.Scalar { return new(Scalar).Set(s) }
+
+func (s *Scalar) SetInt64(v int64) kyber.Scalar {
+	if v >= 0 {
+		s.inner.SetUint64(uint64(v))
+	} else {
+		s.inner.SetUint64(uint64(-v))
+		s.inner.Neg()
+	}
+
+	return s
+}
+
+func (s *Scalar) Zero() kyber.Scalar { s.inner.SetUint64(0); return s }
+
+func (s *Scalar) Add(a, b kyber.Scalar) kyber.Scalar {
+	aa, bb := a.(*Scalar), b.(*Scalar)
+	s.inner.Add(&aa.inner, &bb.inner)
+	return s
+}
+
+func (s *Scalar) Sub(a, b kyber.Scalar) kyber.Scalar {
+	aa, bb := a.(*Scalar), b.(*Scalar)
+	s.inner.Sub(&aa.inner, &bb.inner)
+	return s
+}
+
+func (s *Scalar) Neg(a kyber.Scalar) kyber.Scalar {
+	s.Set(a)
+	s.inner.Neg()
+	return s
+}
+
+func (s *Scalar) One() kyber.Scalar { s.inner.SetUint64(1); return s }
+
+func (s *Scalar) Mul(a, b kyber.Scalar) kyber.Scalar {
+	aa, bb := a.(*Scalar), b.(*Scalar)
+	s.inner.Mul(&aa.inner, &bb.inner)
+	return s
+}
+
+func (s *Scalar) Div(a, b kyber.Scalar) kyber.Scalar { return s.Mul(new(Scalar).Inv(b), a) }
+
+func (s *Scalar) Inv(a kyber.Scalar) kyber.Scalar {
+	aa := a.(*Scalar)
+	s.inner.Inv(&aa.inner)
+	return s
+}
+
+type zeroReader struct{}
+
+func (zeroReader) Read(p []byte) (n int, err error) {
+	for i := range p {
+		p[i] = 0
+	}
+	return len(p), nil
+}
+
+func (s *Scalar) Pick(stream cipher.Stream) kyber.Scalar {
+	err := s.inner.Random(cipher.StreamReader{S: stream, R: zeroReader{}})
+	if err != nil {
+		panic(err)
+	}
+	return s
+}
+
+func (s *Scalar) SetBytes(data []byte) kyber.Scalar { s.inner.SetBytes(data); return s }

--- a/pairing/bls12381/suite.go
+++ b/pairing/bls12381/suite.go
@@ -1,0 +1,59 @@
+package bls12381
+
+import (
+	"crypto/cipher"
+	"crypto/sha256"
+	"hash"
+	"io"
+
+	circl "github.com/cloudflare/circl/ecc/bls12381"
+	"go.dedis.ch/kyber/v3"
+	"go.dedis.ch/kyber/v3/pairing"
+	"go.dedis.ch/kyber/v3/util/random"
+	"go.dedis.ch/kyber/v3/xof/blake2xb"
+)
+
+var _ pairing.Suite = Suite{}
+
+type Suite struct{}
+
+func NewSuite() (s Suite) { return }
+
+func (s Suite) String() string  { return "bls12381" }
+func (s Suite) G1() kyber.Group { return G1 }
+func (s Suite) G2() kyber.Group { return G2 }
+func (s Suite) GT() kyber.Group { return GT }
+func (s Suite) Pair(p1, p2 kyber.Point) kyber.Point {
+	aa, bb := p1.(*G1Elt), p2.(*G2Elt)
+	return &GTElt{*circl.Pair(&aa.inner, &bb.inner)}
+}
+func (s Suite) ValidatePairing(p1, p2, p3, p4 kyber.Point) bool {
+	a, b := p1.(*G1Elt), p2.(*G2Elt)
+	c, d := p3.(*G1Elt), p4.(*G2Elt)
+	out := circl.ProdPairFrac(
+		[]*circl.G1{&a.inner, &c.inner},
+		[]*circl.G2{&b.inner, &d.inner},
+		[]int{1, -1},
+	)
+	return out.IsIdentity()
+}
+
+func (s Suite) Read(r io.Reader, objs ...interface{}) error {
+	panic("Suite.Read(): deprecated in drand")
+}
+
+func (s Suite) Write(w io.Writer, objs ...interface{}) error {
+	panic("Suite.Write(): deprecated in drand")
+}
+
+func (s Suite) Hash() hash.Hash {
+	return sha256.New()
+}
+
+func (s Suite) XOF(seed []byte) kyber.XOF {
+	return blake2xb.New(seed)
+}
+
+func (s Suite) RandomStream() cipher.Stream {
+	return random.New()
+}

--- a/pairing/bls12381/suite_test.go
+++ b/pairing/bls12381/suite_test.go
@@ -1,0 +1,404 @@
+package bls12381_test
+
+import (
+	"bytes"
+	"crypto/cipher"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.dedis.ch/kyber/v3"
+	this "go.dedis.ch/kyber/v3/pairing/bls12381"
+	"go.dedis.ch/kyber/v3/util/random"
+)
+
+// Code extracted from kyber/utils/test
+// TODO: expose API in forked drand/kyber
+// Apply a generic set of validation tests to a cryptographic Group,
+// using a given source of [pseudo-]randomness.
+//
+// Returns a log of the pseudorandom Points produced in the test,
+// for comparison across alternative implementations
+// that are supposed to be equivalent.
+func testGroup(t *testing.T, g kyber.Group, rand cipher.Stream) []kyber.Point {
+	t.Logf("\nTesting group '%s': %d-byte Point, %d-byte Scalar\n",
+		g.String(), g.PointLen(), g.ScalarLen())
+
+	points := make([]kyber.Point, 0)
+	ptmp := g.Point()
+	stmp := g.Scalar()
+	pzero := g.Point().Null()
+	szero := g.Scalar().Zero()
+	sone := g.Scalar().One()
+
+	// Do a simple Diffie-Hellman test
+	s1 := g.Scalar().Pick(rand)
+	s2 := g.Scalar().Pick(rand)
+	if s1.Equal(szero) {
+		t.Fatalf("first secret is scalar zero %v", s1)
+	}
+	if s2.Equal(szero) {
+		t.Fatalf("second secret is scalar zero %v", s2)
+	}
+	if s1.Equal(s2) {
+		t.Fatalf("not getting unique secrets: picked %s twice", s1)
+	}
+
+	gen := g.Point().Base()
+	points = append(points, gen)
+
+	// Sanity-check relationship between addition and multiplication
+	p1 := g.Point().Add(gen, gen)
+	p2 := g.Point().Mul(stmp.SetInt64(2), nil)
+	if !p1.Equal(p2) {
+		t.Fatalf("multiply by two doesn't work: %v == %v (+) %[2]v != %[2]v (x) 2 == %v", p1, gen, p2)
+	}
+	p1.Add(p1, p1)
+	p2.Mul(stmp.SetInt64(4), nil)
+	if !p1.Equal(p2) {
+		t.Fatalf("multiply by four doesn't work: %v (+) %[1]v != %v (x) 4 == %v",
+			g.Point().Add(gen, gen), gen, p2)
+	}
+	points = append(points, p1)
+
+	// Find out if this curve has a prime order:
+	// if the curve does not offer a method IsPrimeOrder,
+	// then assume that it is.
+	type canCheckPrimeOrder interface {
+		IsPrimeOrder() bool
+	}
+	primeOrder := true
+	if gpo, ok := g.(canCheckPrimeOrder); ok {
+		primeOrder = gpo.IsPrimeOrder()
+	}
+
+	// Verify additive and multiplicative identities of the generator.
+	// TODO: Check GT exp
+	/*fmt.Println("Inverse of base")*/
+	//f := ptmp.Base().(*KyberGT).f
+	//newFp12(nil).inverse(f, f)
+	//fmt.Printf("\n-Inverse: %v\n", f)
+	//fmt.Println("Multiply by -1")
+	ptmp.Mul(stmp.SetInt64(-1), nil).Add(ptmp, gen)
+	/*fmt.Printf(" \n\nChecking equality additive identity\nptmp: %v \n\n zero %v\n", ptmp, pzero)*/
+	if !ptmp.Equal(pzero) {
+		t.Fatalf("generator additive identity doesn't work: (scalar -1 %v) %v (x) -1 (+) %v = %v != %v the group point identity",
+			stmp.SetInt64(-1), ptmp.Mul(stmp.SetInt64(-1), nil), gen, ptmp.Mul(stmp.SetInt64(-1), nil).Add(ptmp, gen), pzero)
+	}
+	// secret.Inv works only in prime-order groups
+	if primeOrder {
+		ptmp.Mul(stmp.SetInt64(2), nil).Mul(stmp.Inv(stmp), ptmp)
+		if !ptmp.Equal(gen) {
+			t.Fatalf("generator multiplicative identity doesn't work:\n%v (x) %v = %v\n%[3]v (x) %v = %v",
+				ptmp.Base().String(), stmp.SetInt64(2).String(),
+				ptmp.Mul(stmp.SetInt64(2), nil).String(),
+				stmp.Inv(stmp).String(),
+				ptmp.Mul(stmp.SetInt64(2), nil).Mul(stmp.Inv(stmp), ptmp).String())
+		}
+	}
+
+	p1.Mul(s1, gen)
+	p2.Mul(s2, gen)
+	if p1.Equal(p2) {
+		t.Fatalf("encryption isn't producing unique points: %v (x) %v == %v (x) %[2]v == %[4]v", s1, gen, s2, p1)
+	}
+	points = append(points, p1)
+
+	dh1 := g.Point().Mul(s2, p1)
+	dh2 := g.Point().Mul(s1, p2)
+	if !dh1.Equal(dh2) {
+		t.Fatalf("Diffie-Hellman didn't work: %v == %v (x) %v != %v (x) %v == %v", dh1, s2, p1, s1, p2, dh2)
+	}
+	points = append(points, dh1)
+	//t.Logf("shared secret = %v", dh1)
+
+	// Test secret inverse to get from dh1 back to p1
+	if primeOrder {
+		ptmp.Mul(g.Scalar().Inv(s2), dh1)
+		if !ptmp.Equal(p1) {
+			t.Fatalf("Scalar inverse didn't work: %v != (-)%v (x) %v == %v", p1, s2, dh1, ptmp)
+		}
+	}
+
+	// Zero and One identity secrets
+	//println("dh1^0 = ",ptmp.Mul(dh1, szero).String())
+	if !ptmp.Mul(szero, dh1).Equal(pzero) {
+		t.Fatalf("Encryption with secret=0 didn't work: %v (x) %v == %v != %v", szero, dh1, ptmp, pzero)
+	}
+	if !ptmp.Mul(sone, dh1).Equal(dh1) {
+		t.Fatalf("Encryption with secret=1 didn't work: %v (x) %v == %v != %[2]v", sone, dh1, ptmp)
+	}
+
+	// Additive homomorphic identities
+	ptmp.Add(p1, p2)
+	stmp.Add(s1, s2)
+	pt2 := g.Point().Mul(stmp, gen)
+	if !pt2.Equal(ptmp) {
+		t.Fatalf("Additive homomorphism doesn't work: %v + %v == %v, %[3]v (x) %v == %v != %v == %v (+) %v",
+			s1, s2, stmp, gen, pt2, ptmp, p1, p2)
+	}
+	ptmp.Sub(p1, p2)
+	stmp.Sub(s1, s2)
+	pt2.Mul(stmp, gen)
+	if !pt2.Equal(ptmp) {
+		t.Fatalf("Additive homomorphism doesn't work: %v - %v == %v, %[3]v (x) %v == %v != %v == %v (-) %v",
+			s1, s2, stmp, gen, pt2, ptmp, p1, p2)
+	}
+	st2 := g.Scalar().Neg(s2)
+	st2.Add(s1, st2)
+	if !stmp.Equal(st2) {
+		t.Fatalf("Scalar.Neg doesn't work: -%v == %v, %[2]v + %v == %v != %v",
+			s2, g.Scalar().Neg(s2), s1, st2, stmp)
+	}
+	pt2.Neg(p2).Add(pt2, p1)
+	if !pt2.Equal(ptmp) {
+		t.Fatalf("Point.Neg doesn't work: (-)%v == %v, %[2]v (+) %v == %v != %v",
+			p2, g.Point().Neg(p2), p1, pt2, ptmp)
+	}
+
+	// Multiplicative homomorphic identities
+	stmp.Mul(s1, s2)
+	if !ptmp.Mul(stmp, gen).Equal(dh1) {
+		t.Fatalf("Multiplicative homomorphism doesn't work: %v * %v == %v, %[2]v (x) %v == %v != %v",
+			s1, s2, stmp, gen, ptmp, dh1)
+	}
+	if primeOrder {
+		st2.Inv(s2)
+		st2.Mul(st2, stmp)
+		if !st2.Equal(s1) {
+			t.Fatalf("Scalar division doesn't work: %v^-1 * %v == %v * %[2]v == %[4]v != %v",
+				s2, stmp, g.Scalar().Inv(s2), st2, s1)
+		}
+		st2.Div(stmp, s2)
+		if !st2.Equal(s1) {
+			t.Fatalf("Scalar division doesn't work: %v / %v == %v != %v",
+				stmp, s2, st2, s1)
+		}
+	}
+
+	pick := func(rand cipher.Stream) (p kyber.Point) {
+		defer func() {
+			/*if err := recover(); err != nil {*/
+			//// TODO implement Pick for GT
+			//p = g.Point().Mul(g.Scalar().Pick(rand), nil)
+			//return
+			/*}*/
+		}()
+		p = g.Point().Pick(rand)
+		return
+	}
+
+	// Test randomly picked points
+	last := gen
+	for i := 0; i < 5; i++ {
+		// TODO fork kyber and make that an interface
+		rgen := pick(rand)
+		if rgen.Equal(last) {
+			t.Fatalf("Pick() not producing unique points: got %v twice", rgen)
+		}
+		last = rgen
+
+		ptmp.Mul(stmp.SetInt64(-1), rgen).Add(ptmp, rgen)
+		if !ptmp.Equal(pzero) {
+			t.Fatalf("random generator fails additive identity: %v (x) %v == %v, %v (+) %[3]v == %[5]v != %v",
+				g.Scalar().SetInt64(-1), rgen, g.Point().Mul(g.Scalar().SetInt64(-1), rgen),
+				rgen, g.Point().Mul(g.Scalar().SetInt64(-1), rgen), pzero)
+		}
+		if primeOrder {
+			ptmp.Mul(stmp.SetInt64(2), rgen).Mul(stmp.Inv(stmp), ptmp)
+			if !ptmp.Equal(rgen) {
+				t.Fatalf("random generator fails multiplicative identity: %v (x) (2 (x) %v) == %v != %[2]v",
+					stmp, rgen, ptmp)
+			}
+		}
+		points = append(points, rgen)
+	}
+
+	// Test encoding and decoding
+	buf := new(bytes.Buffer)
+	for i := 0; i < 5; i++ {
+		buf.Reset()
+		s := g.Scalar().Pick(rand)
+		if _, err := s.MarshalTo(buf); err != nil {
+			t.Fatalf("encoding of secret fails: " + err.Error())
+		}
+		if _, err := stmp.UnmarshalFrom(buf); err != nil {
+			t.Fatalf("decoding of secret fails: " + err.Error())
+		}
+		if !stmp.Equal(s) {
+			t.Fatalf("decoding produces different secret than encoded")
+		}
+
+		buf.Reset()
+		p := pick(rand)
+		if _, err := p.MarshalTo(buf); err != nil {
+			t.Fatalf("encoding of point fails: " + err.Error())
+		}
+		if _, err := ptmp.UnmarshalFrom(buf); err != nil {
+			t.Fatalf("decoding of point fails: " + err.Error())
+		}
+
+		if !ptmp.Equal(p) {
+			t.Fatalf("decoding produces different point than encoded")
+		}
+	}
+
+	// Test that we can marshal/ unmarshal null point
+	pzero = g.Point().Null()
+	b, _ := pzero.MarshalBinary()
+	repzero := g.Point()
+	err := repzero.UnmarshalBinary(b)
+	if err != nil {
+		t.Fatalf("Could not unmarshall binary %v: %v", b, err)
+	}
+
+	return points
+}
+
+// GroupTest applies a generic set of validation tests to a cryptographic Group.
+func GroupTest(t *testing.T, g kyber.Group) {
+	testGroup(t, g, random.New())
+}
+
+func TestKyberG1(t *testing.T) {
+	GroupTest(t, this.G1)
+}
+
+func TestKyberG2(t *testing.T) {
+	GroupTest(t, this.G2)
+}
+
+func TestKyberPairingG2(t *testing.T) {
+	s := this.Suite{}
+	a := s.G1().Scalar().Pick(s.RandomStream())
+	b := s.G2().Scalar().Pick(s.RandomStream())
+	aG := s.G1().Point().Mul(a, nil)
+	bH := s.G2().Point().Mul(b, nil)
+	ab := s.G1().Scalar().Mul(a, b)
+	abG := s.G1().Point().Mul(ab, nil)
+	// e(aG, bG) = e(G,H)^(ab)
+	p1 := s.Pair(aG, bH)
+	// e((ab)G,H) = e(G,H)^(ab)
+	p2 := s.Pair(abG, s.G2().Point().Base())
+	require.True(t, p1.Equal(p2))
+	require.True(t, s.ValidatePairing(aG, bH, abG.Clone(), s.G2().Point().Base()))
+
+	pRandom := s.Pair(aG, s.G2().Point().Pick(s.RandomStream()))
+	require.False(t, p1.Equal(pRandom))
+	pRandom = s.Pair(s.G1().Point().Pick(s.RandomStream()), bH)
+	require.False(t, p1.Equal(pRandom))
+}
+
+func TestRacePairings(t *testing.T) {
+	s := this.Suite{}
+	a := s.G1().Scalar().Pick(s.RandomStream())
+	aG := s.G1().Point().Mul(a, nil)
+	B := s.G2().Point().Pick(s.RandomStream())
+	aB := s.G2().Point().Mul(a, B.Clone())
+	wg := sync.WaitGroup{}
+	for i := 0; i < 10; i++ {
+		wg.Add(1)
+		go func() {
+			//  e(p1,p2) =?= e(inv1^-1, inv2^-1)
+			s.ValidatePairing(aG, B, s.G1().Point(), aB)
+			wg.Done()
+		}()
+	}
+	wg.Wait()
+}
+
+func BenchmarkPairingSeparate(bb *testing.B) {
+	s := this.Suite{}
+	a := s.G1().Scalar().Pick(s.RandomStream())
+	b := s.G2().Scalar().Pick(s.RandomStream())
+	aG := s.G1().Point().Mul(a, nil)
+	bH := s.G2().Point().Mul(b, nil)
+	ab := s.G1().Scalar().Mul(a, b)
+	abG := s.G1().Point().Mul(ab, nil)
+	bb.ResetTimer()
+	for i := 0; i < bb.N; i++ {
+
+		// e(aG, bG) = e(G,H)^(ab)
+		p1 := s.Pair(aG, bH)
+		// e((ab)G,H) = e(G,H)^(ab)
+		p2 := s.Pair(abG, s.G2().Point().Base())
+		if !p1.Equal(p2) {
+			panic("aie")
+		}
+	}
+}
+
+func BenchmarkPairingInv(bb *testing.B) {
+	s := this.Suite{}
+	a := s.G1().Scalar().Pick(s.RandomStream())
+	b := s.G2().Scalar().Pick(s.RandomStream())
+	aG := s.G1().Point().Mul(a, nil)
+	bH := s.G2().Point().Mul(b, nil)
+	ab := s.G1().Scalar().Mul(a, b)
+	abG := s.G1().Point().Mul(ab, nil)
+	bb.ResetTimer()
+	for i := 0; i < bb.N; i++ {
+		if !s.ValidatePairing(aG, bH, abG.Clone(), s.G2().Point().Base()) {
+			panic("aie")
+		}
+	}
+}
+
+var suite = this.Suite{}
+
+func NewElement() kyber.Scalar {
+	return suite.G1().Scalar()
+}
+func NewG1() kyber.Point {
+	return suite.G1().Point().Base()
+}
+func NewG2() kyber.Point {
+	return suite.G2().Point().Base()
+}
+func Pair(a, b kyber.Point) kyber.Point {
+	return suite.Pair(a, b)
+}
+func TestBasicPairing(t *testing.T) {
+
+	// we test a * b = c + d
+	a := NewElement().Pick(random.New())
+	b := NewElement().Pick(random.New())
+	c := NewElement().Pick(random.New())
+	d := NewElement().Sub(NewElement().Mul(a, b), c)
+
+	// check in the clear
+	ab := NewElement().Mul(a, b)
+	cd := NewElement().Add(c, d)
+	require.True(t, ab.Equal(cd))
+
+	// check in the exponent now with the following
+	// e(aG1,bG2) = e(cG1,G2) * e(G1,dG2) <=>
+	// e(G1,G2)^(a*b) = e(G1,G2)^c * e(G1,G2)^d
+	// e(G1,G2)^(a*b) = e(G1,G2)^(c + d)
+	aG := NewG1().Mul(a, nil)
+	bG := NewG2().Mul(b, nil)
+	left := Pair(aG, bG)
+
+	cG := NewG1().Mul(c, nil)
+	right1 := Pair(cG, NewG2())
+	dG := NewG2().Mul(d, nil)
+	right2 := Pair(NewG1(), dG)
+	right := suite.GT().Point().Add(right1, right2)
+	require.True(t, left.Equal(right))
+
+	// Test if addition works in GT
+	mright := right.Clone().Neg(right)
+	res := mright.Add(mright, right)
+	require.True(t, res.Equal(suite.GT().Point().Null()))
+
+	// Test if Sub works in GT
+	expZero := right.Clone().Sub(right, right)
+	require.True(t, expZero.Equal(suite.GT().Point().Null()))
+
+	//  Test if scalar mul works in GT
+	// e(aG,G) == e(G,G)^a
+	left = Pair(aG, suite.G2().Point().Base())
+	right = Pair(suite.G1().Point().Base(), suite.G2().Point().Base())
+	right = right.Mul(a, right)
+	require.True(t, left.Equal(right))
+}

--- a/pairing/bn256/adapter.go
+++ b/pairing/bn256/adapter.go
@@ -1,8 +1,7 @@
-package pairing
+package bn256
 
 import (
 	"go.dedis.ch/kyber/v3"
-	"go.dedis.ch/kyber/v3/pairing/bn256"
 )
 
 // SuiteBn256 is an adapter that implements the suites.Suite interface so that
@@ -13,14 +12,14 @@ import (
 // compatible with public keys only (group G2) where the signature must be
 // used as a point from the group G1.
 type SuiteBn256 struct {
-	Suite
+	*Suite
 	kyber.Group
 }
 
 // NewSuiteBn256 makes a new BN256 suite
 func NewSuiteBn256() *SuiteBn256 {
 	return &SuiteBn256{
-		Suite: bn256.NewSuite(),
+		Suite: NewSuite(),
 	}
 }
 

--- a/pairing/bn256/adapter_test.go
+++ b/pairing/bn256/adapter_test.go
@@ -1,4 +1,4 @@
-package pairing
+package bn256
 
 import (
 	"testing"

--- a/sign/bdn/bdn_test.go
+++ b/sign/bdn/bdn_test.go
@@ -6,14 +6,13 @@ import (
 
 	"github.com/stretchr/testify/require"
 	"go.dedis.ch/kyber/v3"
-	"go.dedis.ch/kyber/v3/pairing"
 	"go.dedis.ch/kyber/v3/pairing/bn256"
 	"go.dedis.ch/kyber/v3/sign"
 	"go.dedis.ch/kyber/v3/sign/bls"
 	"go.dedis.ch/kyber/v3/util/random"
 )
 
-var suite = pairing.NewSuiteBn256()
+var suite = bn256.NewSuiteBn256()
 var two = suite.Scalar().Add(suite.Scalar().One(), suite.Scalar().One())
 var three = suite.Scalar().Add(two, suite.Scalar().One())
 

--- a/sign/mask_test.go
+++ b/sign/mask_test.go
@@ -6,13 +6,13 @@ import (
 
 	"github.com/stretchr/testify/require"
 	"go.dedis.ch/kyber/v3"
-	"go.dedis.ch/kyber/v3/pairing"
+	"go.dedis.ch/kyber/v3/pairing/bn256"
 	"go.dedis.ch/kyber/v3/util/key"
 )
 
 const n = 17
 
-var suite = pairing.NewSuiteBn256()
+var suite = bn256.NewSuiteBn256()
 var publics []kyber.Point
 
 func init() {

--- a/sign/tbls/tbls_test.go
+++ b/sign/tbls/tbls_test.go
@@ -4,15 +4,24 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	"go.dedis.ch/kyber/v3/pairing"
+	"go.dedis.ch/kyber/v3/pairing/bls12381"
 	"go.dedis.ch/kyber/v3/pairing/bn256"
 	"go.dedis.ch/kyber/v3/share"
 	"go.dedis.ch/kyber/v3/sign/bls"
 )
 
-func TestTBLS(test *testing.T) {
+func TestTBLS_BN256(test *testing.T) {
+	testTBLS(test, bn256.NewSuite())
+}
+
+func TestTBLS_BLS12381(test *testing.T) {
+	testTBLS(test, bls12381.NewSuite())
+}
+
+func testTBLS(test *testing.T, suite pairing.Suite) {
 	var err error
 	msg := []byte("Hello threshold Boneh-Lynn-Shacham")
-	suite := bn256.NewSuite()
 	n := 10
 	t := n/2 + 1
 	secret := suite.G1().Scalar().Pick(suite.RandomStream())

--- a/suites/all.go
+++ b/suites/all.go
@@ -3,7 +3,6 @@ package suites
 import (
 	"go.dedis.ch/kyber/v3/group/edwards25519"
 	"go.dedis.ch/kyber/v3/group/nist"
-	"go.dedis.ch/kyber/v3/pairing"
 	"go.dedis.ch/kyber/v3/pairing/bn256"
 )
 
@@ -15,7 +14,7 @@ func init() {
 	register(bn256.NewSuiteG1())
 	register(bn256.NewSuiteG2())
 	register(bn256.NewSuiteGT())
-	register(pairing.NewSuiteBn256())
+	register(bn256.NewSuiteBn256())
 	// This is a constant time implementation that should be
 	// used as much as possible
 	register(edwards25519.NewBlakeSHA256Ed25519())

--- a/suites/all.go
+++ b/suites/all.go
@@ -3,6 +3,7 @@ package suites
 import (
 	"go.dedis.ch/kyber/v3/group/edwards25519"
 	"go.dedis.ch/kyber/v3/group/nist"
+	"go.dedis.ch/kyber/v3/pairing/bls12381"
 	"go.dedis.ch/kyber/v3/pairing/bn256"
 )
 
@@ -15,6 +16,7 @@ func init() {
 	register(bn256.NewSuiteG2())
 	register(bn256.NewSuiteGT())
 	register(bn256.NewSuiteBn256())
+	register(bls12381.NewSuiteBLS12381())
 	// This is a constant time implementation that should be
 	// used as much as possible
 	register(edwards25519.NewBlakeSHA256Ed25519())


### PR DESCRIPTION
This PR adds the functionality of BLS12381 pairings using the CIRCL implementation as backend.

[CIRCL](https://github.com/cloudflare/circl/) implementation uses formally-verified implementation (using fiat-crypto) for the prime field arithmetic.

Fixes #402 