### PR TITLE
Add check for the dkg public key after resharing

### DIFF
--- a/share/dkg/pedersen/dkg_test.go
+++ b/share/dkg/pedersen/dkg_test.go
@@ -668,6 +668,10 @@ func TestDKGResharing(t *testing.T) {
 	newSecret, err := share.RecoverSecret(suite, newSShares, thr, defaultN)
 	require.NoError(t, err)
 	require.Equal(t, oldSecret.String(), newSecret.String())
+	// 3.
+	for i := 0; i < len(dkgs); i++ {
+		require.Equal(t, shares[i].Public(), newShares[i].Public())
+	}
 }
 
 // Test resharing functionality with one node less


### PR DESCRIPTION
Check whether the DKG public key changes before and after resharing among the same group of nodes.

Closes #489 