### PR TITLE
Add CI steps for 32bit architectures

### DIFF
--- a/.github/workflows/test_on_pr.yml
+++ b/.github/workflows/test_on_pr.yml
@@ -29,12 +29,9 @@ jobs:
         echo "::error:: Could not start CI tests due to missing *safe PR* label."
         exit 1
     
-  test:
+  test-mac:
     needs: permission
-    strategy:
-      matrix:
-        platform: [macos-latest, windows-latest, ubuntu-latest]
-    runs-on: ${{matrix.platform}}
+    runs-on: macos-latest
     env:
       DBGSYNCLOG: trace
       DBGSYNCON: true
@@ -48,18 +45,51 @@ jobs:
       uses: actions/checkout@v3
       with:
         ref: ${{ github.event.pull_request.head.sha }}
-        fetch-depth: 0
 
     - name: Test without coverage
-      if: matrix.platform == 'macos-latest' || matrix.platform == 'windows-latest'
       run: make test
 
+  test-windows:
+    needs: permission
+    runs-on: windows-latest
+    env:
+      DBGSYNCLOG: trace
+      DBGSYNCON: true
+    steps:
+    - name: Set up Go ^1.13
+      uses: actions/setup-go@v3
+      with:
+        go-version: ^1.13
+
+    - name: Check out code into the Go module directory
+      uses: actions/checkout@v3
+      with:
+        ref: ${{ github.event.pull_request.head.sha }}
+
+    - name: Test without coverage
+      run: make test
+
+  test-ubuntu:
+    needs: permission
+    runs-on: ubuntu-latest
+    env:
+      DBGSYNCLOG: trace
+      DBGSYNCON: true
+    steps:
+    - name: Set up Go ^1.13
+      uses: actions/setup-go@v3
+      with:
+        go-version: ^1.13
+
+    - name: Check out code into the Go module directory
+      uses: actions/checkout@v3
+      with:
+        ref: ${{ github.event.pull_request.head.sha }}
+
     - name: Test with coverage
-      if: matrix.platform == 'ubuntu-latest'
       run: make coverage
 
     - name: SonarCloud scan
-      if: matrix.platform == 'ubuntu-latest'
       uses: sonarsource/sonarcloud-github-action@master
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -76,4 +106,34 @@ jobs:
           -Dsonar.c.file.suffixes=-
           -Dsonar.cpp.file.suffixes=-
           -Dsonar.objc.file.suffixes=-
-          
+
+  test-ubuntu-x86:
+    needs: permission
+    runs-on: ubuntu-latest
+    env:
+      DBGSYNCLOG: trace
+      DBGSYNCON: true
+    steps:
+    - name: Setup Alpine Linux
+      uses: jirutka/setup-alpine@v1
+      with:
+        arch: x86
+        packages: >
+          golang 
+          make 
+          git 
+          gcc 
+          musl-dev
+
+    - name: Set up Go ^1.13 for x86
+      uses: actions/setup-go@v3
+      with:
+        go-version: ^1.13
+
+    - name: Check out code into the Go module directory for x86
+      uses: actions/checkout@v3
+      with:
+        ref: ${{ github.event.pull_request.head.sha }}
+
+    - name: Test without coverage for x86
+      run: make test

--- a/.github/workflows/test_on_push.yml
+++ b/.github/workflows/test_on_push.yml
@@ -5,11 +5,9 @@ on:
     branches: [ master ]
 
 jobs:
-  test_and_coverage:
-    strategy:
-      matrix:
-        platform: [macos-latest, windows-latest, ubuntu-latest]
-    runs-on: ${{matrix.platform}}
+  test-mac:
+    needs: permission
+    runs-on: macos-latest
     env:
       DBGSYNCLOG: trace
       DBGSYNCON: true
@@ -26,15 +24,51 @@ jobs:
         fetch-depth: 0
 
     - name: Test without coverage
-      if: matrix.platform == 'macos-latest' || matrix.platform == 'windows-latest'
       run: make test
 
+  test-windows:
+    needs: permission
+    runs-on: windows-latest
+    env:
+      DBGSYNCLOG: trace
+      DBGSYNCON: true
+    steps:
+    - name: Set up Go ^1.13
+      uses: actions/setup-go@v3
+      with:
+        go-version: ^1.13
+
+    - name: Check out code into the Go module directory
+      uses: actions/checkout@v3
+      with:
+        ref: ${{ github.event.pull_request.head.sha }}
+        fetch-depth: 0
+
+    - name: Test without coverage
+      run: make test
+
+  test-ubuntu:
+    needs: permission
+    runs-on: ubuntu-latest
+    env:
+      DBGSYNCLOG: trace
+      DBGSYNCON: true
+    steps:
+    - name: Set up Go ^1.13
+      uses: actions/setup-go@v3
+      with:
+        go-version: ^1.13
+
+    - name: Check out code into the Go module directory
+      uses: actions/checkout@v3
+      with:
+        ref: ${{ github.event.pull_request.head.sha }}
+        fetch-depth: 0
+
     - name: Test with coverage
-      if: matrix.platform == 'ubuntu-latest'
       run: make coverage
-        
+
     - name: SonarCloud scan
-      if: matrix.platform == 'ubuntu-latest'
       uses: sonarsource/sonarcloud-github-action@master
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -53,7 +87,38 @@ jobs:
           -Dsonar.objc.file.suffixes=-
 
     - name: Send coverage
-      if: matrix.platform == 'ubuntu-latest'
       uses: shogo82148/actions-goveralls@v1
       with:
         path-to-profile: profile.cov
+
+  test-ubuntu-x86:
+    needs: permission
+    runs-on: ubuntu-latest
+    env:
+      DBGSYNCLOG: trace
+      DBGSYNCON: true
+    steps:
+    - name: Setup Alpine Linux
+      uses: jirutka/setup-alpine@v1
+      with:
+        arch: x86
+        packages: >
+          golang 
+          make 
+          git 
+          gcc 
+          musl-dev
+
+    - name: Set up Go ^1.13 for x86
+      uses: actions/setup-go@v3
+      with:
+        go-version: ^1.13
+
+    - name: Check out code into the Go module directory for x86
+      uses: actions/checkout@v3
+      with:
+        ref: ${{ github.event.pull_request.head.sha }}
+        fetch-depth: 0
+
+    - name: Test without coverage for x86
+      run: make test


### PR DESCRIPTION
This PR modifies the CI tests run on push and on PR opening with tests for x86 architectures. It's used as testing for #502 