### PR TITLE
Simplified 32-bit fail fix

### DIFF
--- a/internal/test/threshold.go
+++ b/internal/test/threshold.go
@@ -26,11 +26,11 @@ func ThresholdTest(test *testing.T, keyGroup kyber.Group, scheme sign.ThresholdS
 			require.Nil(tt, scheme.VerifyPartial(pubPoly, msg, sig))
 			idx, err := scheme.IndexOf(sig)
 			require.NoError(tt, err)
-			require.Equal(tt, x.I, idx)
+			require.Equal(tt, int(x.I), idx)
 			sigShares = append(sigShares, sig)
 			idx, err = scheme.IndexOf(sig)
 			require.NoError(tt, err)
-			require.Equal(tt, idx, x.I)
+			require.Equal(tt, idx, int(x.I))
 		}
 		sig, err := scheme.Recover(pubPoly, msg, sigShares, t, n)
 		require.Nil(tt, err)

--- a/share/dkg/pedersen/dkg.go
+++ b/share/dkg/pedersen/dkg.go
@@ -348,7 +348,7 @@ func (d *DistKeyGenerator) Deals() (*DealBundle, error) {
 	deals := make([]Deal, 0, len(d.c.NewNodes))
 	for _, node := range d.c.NewNodes {
 		// compute share
-		si := d.dpriv.Eval(int(node.Index)).V
+		si := d.dpriv.Eval(node.Index).V
 
 		if d.canReceive && uint32(d.nidx) == node.Index {
 			d.validShares[d.oidx] = si
@@ -467,7 +467,7 @@ func (d *DistKeyGenerator) ProcessDeals(bundles []*DealBundle) (*ResponseBundle,
 				continue
 			}
 			// check if share is valid w.r.t. public commitment
-			comm := pubPoly.Eval(int(d.nidx)).V
+			comm := pubPoly.Eval(d.nidx).V
 			commShare := d.c.Suite.Point().Mul(share, nil)
 			if !comm.Equal(commShare) {
 				d.c.Error("Deal share invalid wrt public poly")
@@ -478,7 +478,7 @@ func (d *DistKeyGenerator) ProcessDeals(bundles []*DealBundle) (*ResponseBundle,
 			if d.isResharing {
 				// check that the evaluation this public polynomial at 0,
 				// corresponds to the commitment of the previous the dealer's index
-				oldShareCommit := d.olddpub.Eval(int(bundle.DealerIndex)).V
+				oldShareCommit := d.olddpub.Eval(bundle.DealerIndex).V
 				publicCommit := pubPoly.Commit()
 				if !oldShareCommit.Equal(publicCommit) {
 					// inconsistent share from old member
@@ -689,7 +689,7 @@ func (d *DistKeyGenerator) ProcessResponses(bundles []*ResponseBundle) (res *Res
 			continue
 		}
 		// create justifications for the requested share
-		var sh = d.dpriv.Eval(int(shareIndex)).V
+		var sh = d.dpriv.Eval(shareIndex).V
 		justifications = append(justifications, Justification{
 			ShareIndex: shareIndex,
 			Share:      sh,
@@ -788,7 +788,7 @@ func (d *DistKeyGenerator) ProcessJustifications(bundles []*JustificationBundle)
 			}
 			// compare commit and public poly
 			commit := d.c.Suite.Point().Mul(justif.Share, nil)
-			expected := pubPoly.Eval(int(justif.ShareIndex)).V
+			expected := pubPoly.Eval(justif.ShareIndex).V
 			if !commit.Equal(expected) {
 				// invalid justification - evict
 				d.evicted = append(d.evicted, bundle.DealerIndex)
@@ -798,7 +798,7 @@ func (d *DistKeyGenerator) ProcessJustifications(bundles []*JustificationBundle)
 			if d.isResharing {
 				// check that the evaluation this public polynomial at 0,
 				// corresponds to the commitment of the previous the dealer's index
-				oldShareCommit := d.olddpub.Eval(int(bundle.DealerIndex)).V
+				oldShareCommit := d.olddpub.Eval(bundle.DealerIndex).V
 				publicCommit := pubPoly.Commit()
 				if !oldShareCommit.Equal(publicCommit) {
 					// inconsistent share from old member
@@ -895,7 +895,7 @@ func (d *DistKeyGenerator) computeResharingResult() (*Result, error) {
 		// share of dist. secret. Invertion of rows/column
 		shares = append(shares, &share.PriShare{
 			V: sh,
-			I: int(n.Index),
+			I: n.Index,
 		})
 		validDealers = append(validDealers, n.Index)
 	}
@@ -907,7 +907,7 @@ func (d *DistKeyGenerator) computeResharingResult() (*Result, error) {
 		return nil, err
 	}
 	privateShare := &share.PriShare{
-		I: int(d.nidx),
+		I: d.nidx,
 		V: priPoly.Secret(),
 	}
 
@@ -923,7 +923,7 @@ func (d *DistKeyGenerator) computeResharingResult() (*Result, error) {
 			if coeffs[j] == nil {
 				continue
 			}
-			tmpCoeffs = append(tmpCoeffs, &share.PubShare{I: int(j), V: coeffs[j][i]})
+			tmpCoeffs = append(tmpCoeffs, &share.PubShare{I: j, V: coeffs[j][i]})
 		}
 
 		// using the old threshold / length because there are at most
@@ -1030,7 +1030,7 @@ func (d *DistKeyGenerator) computeDKGResult() (*Result, error) {
 		Key: &DistKeyShare{
 			Commits: commits,
 			Share: &share.PriShare{
-				I: int(d.nidx),
+				I: d.nidx,
 				V: finalShare,
 			},
 		},

--- a/share/dkg/pedersen/dkg_test.go
+++ b/share/dkg/pedersen/dkg_test.go
@@ -629,7 +629,7 @@ func TestDKGThreshold(t *testing.T) {
 			continue
 		}
 		for _, res := range results {
-			if res.Key.Share.I != int(n.Index) {
+			if res.Key.Share.I != n.Index {
 				continue
 			}
 			for _, nodeQual := range res.QUAL {
@@ -1055,7 +1055,7 @@ func TestDKGTooManyComplaints(t *testing.T) {
 			continue
 		}
 		for _, res := range results {
-			if res.Key.Share.I != int(n.Index) {
+			if res.Key.Share.I != n.Index {
 				continue
 			}
 			for _, nodeQual := range res.QUAL {

--- a/share/dkg/rabin/dkg.go
+++ b/share/dkg/rabin/dkg.go
@@ -649,7 +649,7 @@ func (d *DistKeyGenerator) DistKeyShare() (*DistKeyShare, error) {
 	return &DistKeyShare{
 		Commits: commits,
 		Share: &share.PriShare{
-			I: int(d.index),
+			I: d.index,
 			V: sh,
 		},
 	}, nil

--- a/share/poly.go
+++ b/share/poly.go
@@ -27,7 +27,7 @@ var errorCoeffs = errors.New("different number of coefficients")
 
 // PriShare represents a private share.
 type PriShare struct {
-	I int          // Index of the private share
+	I uint32       // Index of the private share
 	V kyber.Scalar // Value of the private share
 }
 
@@ -81,7 +81,7 @@ func (p *PriPoly) Secret() kyber.Scalar {
 }
 
 // Eval computes the private share v = p(i).
-func (p *PriPoly) Eval(i int) *PriShare {
+func (p *PriPoly) Eval(i uint32) *PriShare {
 	xi := p.g.Scalar().SetInt64(1 + int64(i))
 	v := p.g.Scalar().Zero()
 	for j := p.Threshold() - 1; j >= 0; j-- {
@@ -95,7 +95,7 @@ func (p *PriPoly) Eval(i int) *PriShare {
 func (p *PriPoly) Shares(n int) []*PriShare {
 	shares := make([]*PriShare, n)
 	for i := range shares {
-		shares[i] = p.Eval(i)
+		shares[i] = p.Eval(uint32(i))
 	}
 	return shares
 }
@@ -232,7 +232,7 @@ func xyScalar(g kyber.Group, shares []*PriShare, t, n int) (map[int]kyber.Scalar
 		if s == nil || s.V == nil || s.I < 0 {
 			continue
 		}
-		idx := s.I
+		idx := int(s.I)
 		x[idx] = g.Scalar().SetInt64(int64(idx + 1))
 		y[idx] = s.V
 		if len(x) == t {
@@ -296,7 +296,7 @@ func (p *PriPoly) String() string {
 
 // PubShare represents a public share.
 type PubShare struct {
-	I int         // Index of the public share
+	I uint32      // Index of the public share
 	V kyber.Point // Value of the public share
 }
 
@@ -336,7 +336,7 @@ func (p *PubPoly) Commit() kyber.Point {
 }
 
 // Eval computes the public share v = p(i).
-func (p *PubPoly) Eval(i int) *PubShare {
+func (p *PubPoly) Eval(i uint32) *PubShare {
 	xi := p.g.Scalar().SetInt64(1 + int64(i)) // x-coordinate of this share
 	v := p.g.Point().Null()
 	for j := p.Threshold() - 1; j >= 0; j-- {
@@ -350,7 +350,7 @@ func (p *PubPoly) Eval(i int) *PubShare {
 func (p *PubPoly) Shares(n int) []*PubShare {
 	shares := make([]*PubShare, n)
 	for i := range shares {
-		shares[i] = p.Eval(i)
+		shares[i] = p.Eval(uint32(i))
 	}
 	return shares
 }
@@ -433,7 +433,7 @@ func xyCommit(g kyber.Group, shares []*PubShare, t, n int) (map[int]kyber.Scalar
 		if s == nil || s.V == nil || s.I < 0 {
 			continue
 		}
-		idx := s.I
+		idx := int(s.I)
 		x[idx] = g.Scalar().SetInt64(int64(idx + 1))
 		y[idx] = s.V
 		if len(x) == t {

--- a/share/poly_test.go
+++ b/share/poly_test.go
@@ -396,7 +396,7 @@ func TestRecoverPriPoly(test *testing.T) {
 	reverseRecovered, err := RecoverPriPoly(suite, reverses, t, n)
 	assert.Nil(test, err)
 
-	for i := 0; i < t; i++ {
+	for i := uint32(0); i < uint32(t); i++ {
 		assert.Equal(test, recovered.Eval(i).V.String(), a.Eval(i).V.String())
 		assert.Equal(test, reverseRecovered.Eval(i).V.String(), a.Eval(i).V.String())
 	}
@@ -445,7 +445,7 @@ func TestRefreshDKG(test *testing.T) {
 
 	// Create private DKG shares
 	dkgShares := make([]*PriShare, n)
-	for i := 0; i < n; i++ {
+	for i := uint32(0); i < uint32(n); i++ {
 		acc := g.Scalar().Zero()
 		for j := 0; j < n; j++ { // assuming all participants are in the qualified set
 			acc = g.Scalar().Add(acc, priShares[j][i].V)
@@ -487,10 +487,10 @@ func TestRefreshDKG(test *testing.T) {
 
 	// Handout shares to new nodes column-wise and verify them
 	newDKGShares := make([]*PriShare, n)
-	for i := 0; i < n; i++ {
+	for i := uint32(0); i < uint32(n); i++ {
 		tmpPriShares := make([]*PriShare, n) // column-wise reshuffled sub-shares
 		tmpPubShares := make([]*PubShare, n) // public commitments to old DKG private shares
-		for j := 0; j < n; j++ {
+		for j := uint32(0); j < uint32(n); j++ {
 			// Check 1: Verify that the received individual private subshares s_ji
 			// is correct by evaluating the public commitment vector
 			tmpPriShares[j] = &PriShare{I: j, V: subPriShares[j][i].V} // Shares that participant i gets from j
@@ -517,7 +517,7 @@ func TestRefreshDKG(test *testing.T) {
 	newDKGCommits := make([]kyber.Point, t)
 	for i := 0; i < t; i++ {
 		pubShares := make([]*PubShare, n)
-		for j := 0; j < n; j++ {
+		for j := uint32(0); j < uint32(n); j++ {
 			_, c := subPubPolys[j].Info()
 			pubShares[j] = &PubShare{I: j, V: c[i]}
 		}

--- a/share/pvss/pvss.go
+++ b/share/pvss/pvss.go
@@ -60,7 +60,7 @@ func EncShares(suite Suite, H kyber.Point, X []kyber.Point, secret kyber.Scalar,
 	pubPoly := priPoly.Commit(H)
 
 	// Prepare data for encryption consistency proofs ...
-	indices := make([]int, n)
+	indices := make([]uint32, n)
 	values := make([]kyber.Scalar, n)
 	HS := make([]kyber.Point, n)
 	for i := 0; i < n; i++ {

--- a/share/vss/pedersen/vss.go
+++ b/share/vss/pedersen/vss.go
@@ -144,7 +144,7 @@ func NewDealer(suite Suite, longterm, secret kyber.Scalar, verifiers []kyber.Poi
 	// C = F + G
 	d.deals = make([]*Deal, len(d.verifiers))
 	for i := range d.verifiers {
-		fi := f.Eval(i)
+		fi := f.Eval(uint32(i))
 		d.deals[i] = &Deal{
 			SessionID:   d.sessionID,
 			SecShare:    fi,
@@ -355,7 +355,7 @@ func (v *Verifier) ProcessEncryptedDeal(e *EncryptedDeal) (*Response, error) {
 	if err != nil {
 		return nil, err
 	}
-	if d.SecShare.I != v.index {
+	if int(d.SecShare.I) != v.index {
 		return nil, errors.New("vss: verifier got wrong index from deal")
 	}
 
@@ -578,7 +578,7 @@ func (a *Aggregator) VerifyDeal(d *Deal, inclusion bool) error {
 	}
 
 	fi := d.SecShare
-	if fi.I < 0 || fi.I >= len(a.verifiers) {
+	if fi.I >= uint32(len(a.verifiers)) {
 		return errors.New("vss: index out of bounds in Deal")
 	}
 	// compute fi * G

--- a/share/vss/pedersen/vss_test.go
+++ b/share/vss/pedersen/vss_test.go
@@ -266,7 +266,7 @@ func TestVSSVerifierReceiveDeal(t *testing.T) {
 
 	// wrong index
 	goodIdx := d.SecShare.I
-	d.SecShare.I = (goodIdx - 1) % nbVerifiers
+	d.SecShare.I = (goodIdx - 1) % uint32(nbVerifiers)
 	encD, _ = dealer.EncryptedDeal(0)
 	resp, err = v.ProcessEncryptedDeal(encD)
 	assert.Error(t, err)
@@ -527,9 +527,7 @@ func TestVSSAggregatorVerifyDeal(t *testing.T) {
 	deal.SecShare.I = goodI
 
 	// index not in bounds
-	deal.SecShare.I = -1
-	assert.Error(t, aggr.VerifyDeal(deal, false))
-	deal.SecShare.I = len(verifiersPub)
+	deal.SecShare.I = uint32(len(verifiersPub))
 	assert.Error(t, aggr.VerifyDeal(deal, false))
 
 	// shares invalid in respect to the commitments

--- a/share/vss/rabin/vss.go
+++ b/share/vss/rabin/vss.go
@@ -170,8 +170,9 @@ func NewDealer(suite Suite, longterm, secret kyber.Scalar, verifiers []kyber.Poi
 	// C = F + G
 	d.deals = make([]*Deal, len(d.verifiers))
 	for i := range d.verifiers {
-		fi := f.Eval(i)
-		gi := g.Eval(i)
+		idx := uint32(i)
+		fi := f.Eval(idx)
+		gi := g.Eval(idx)
 		d.deals[i] = &Deal{
 			SessionID:   d.sessionID,
 			SecShare:    fi,
@@ -375,7 +376,7 @@ func (v *Verifier) ProcessEncryptedDeal(e *EncryptedDeal) (*Response, error) {
 	if err != nil {
 		return nil, err
 	}
-	if d.SecShare.I != v.index {
+	if int(d.SecShare.I) != v.index {
 		return nil, errors.New("vss: verifier got wrong index from deal")
 	}
 
@@ -562,7 +563,7 @@ func (a *aggregator) VerifyDeal(d *Deal, inclusion bool) error {
 	if fi.I != gi.I {
 		return errors.New("vss: not the same index for f and g share in Deal")
 	}
-	if fi.I < 0 || fi.I >= len(a.verifiers) {
+	if fi.I < 0 || fi.I >= uint32(len(a.verifiers)) {
 		return errors.New("vss: index out of bounds in Deal")
 	}
 	// compute fi * G + gi * H

--- a/share/vss/rabin/vss_test.go
+++ b/share/vss/rabin/vss_test.go
@@ -245,7 +245,7 @@ func TestVSSVerifierReceiveDeal(t *testing.T) {
 
 	// wrong index
 	goodIdx := d.SecShare.I
-	d.SecShare.I = (goodIdx - 1) % nbVerifiers
+	d.SecShare.I = (goodIdx - 1) % uint32(nbVerifiers)
 	encD, _ = dealer.EncryptedDeal(0)
 	resp, err = v.ProcessEncryptedDeal(encD)
 	assert.Error(t, err)
@@ -443,9 +443,7 @@ func TestVSSAggregatorVerifyDeal(t *testing.T) {
 	deal.RndShare.I = goodI
 
 	// index not in bounds
-	deal.SecShare.I = -1
-	assert.Error(t, aggr.VerifyDeal(deal, false))
-	deal.SecShare.I = len(verifiersPub)
+	deal.SecShare.I = uint32(len(verifiersPub))
 	assert.Error(t, aggr.VerifyDeal(deal, false))
 
 	// shares invalid in respect to the commitments

--- a/sign/dss/dss.go
+++ b/sign/dss/dss.go
@@ -118,7 +118,7 @@ func (d *DSS) PartialSig() (*PartialSig, error) {
 	ps := &PartialSig{
 		Partial: &share.PriShare{
 			V: right.Add(right, beta),
-			I: d.index,
+			I: uint32(d.index),
 		},
 		SessionID: d.sessionID,
 	}
@@ -138,7 +138,7 @@ func (d *DSS) PartialSig() (*PartialSig, error) {
 // received by the same peer. To know whether the distributed signature can be
 // computed after this call, one can use the `EnoughPartialSigs` method.
 func (d *DSS) ProcessPartialSig(ps *PartialSig) error {
-	public, ok := findPub(d.participants, ps.Partial.I)
+	public, ok := findPub(d.participants, int(ps.Partial.I))
 	if !ok {
 		return errors.New("dss: partial signature with invalid index")
 	}
@@ -152,7 +152,7 @@ func (d *DSS) ProcessPartialSig(ps *PartialSig) error {
 		return errors.New("dss: session id do not match")
 	}
 
-	if _, ok := d.partialsIdx[ps.Partial.I]; ok {
+	if _, ok := d.partialsIdx[int(ps.Partial.I)]; ok {
 		return errors.New("dss: partial signature already received from peer")
 	}
 
@@ -166,7 +166,7 @@ func (d *DSS) ProcessPartialSig(ps *PartialSig) error {
 	if !left.Equal(right) {
 		return errors.New("dss: partial signature not valid")
 	}
-	d.partialsIdx[ps.Partial.I] = true
+	d.partialsIdx[int(ps.Partial.I)] = true
 	d.partials = append(d.partials, ps.Partial)
 	return nil
 }

--- a/sign/tbls/tbls.go
+++ b/sign/tbls/tbls.go
@@ -103,7 +103,7 @@ func (s *scheme) VerifyPartial(public *share.PubPoly, msg, sig []byte) error {
 	if err != nil {
 		return err
 	}
-	return s.Scheme.Verify(public.Eval(i).V, msg, sh.Value())
+	return s.Scheme.Verify(public.Eval(uint32(i)).V, msg, sh.Value())
 }
 
 func (s *scheme) VerifyRecovered(public kyber.Point, msg, sig []byte) error {
@@ -123,14 +123,15 @@ func (s *scheme) Recover(public *share.PubPoly, msg []byte, sigs [][]byte, t, n 
 		if err != nil {
 			continue
 		}
-		if err = s.Scheme.Verify(public.Eval(i).V, msg, sh.Value()); err != nil {
+		idx := uint32(i)
+		if err = s.Scheme.Verify(public.Eval(idx).V, msg, sh.Value()); err != nil {
 			continue
 		}
 		point := s.sigGroup.Point()
 		if err := point.UnmarshalBinary(sh.Value()); err != nil {
 			continue
 		}
-		pubShares = append(pubShares, &share.PubShare{I: i, V: point})
+		pubShares = append(pubShares, &share.PubShare{I: idx, V: point})
 		if len(pubShares) >= t {
 			break
 		}


### PR DESCRIPTION
This PR is a simplification for #502 . The error was due to the protobuf decoding of an int field in the PriShare struct, only changing that field should solve the issue and minimise the risk since the changes are now minimal.