### PR TITLE
Method SetIntString in the Scalar interface to create arbitrary large scalars from strings

### DIFF
--- a/group.go
+++ b/group.go
@@ -35,6 +35,9 @@ type Scalar interface {
 	// SetInt64 sets the receiver to a small integer value.
 	SetInt64(v int64) Scalar
 
+	// SetIntString sets the receiver to a string encoded integer value.
+	SetIntString(v string) (Scalar, error)
+
 	// Set to the additive identity (0).
 	Zero() Scalar
 

--- a/group/edwards25519/scalar.go
+++ b/group/edwards25519/scalar.go
@@ -59,6 +59,14 @@ func (s *scalar) SetInt64(v int64) kyber.Scalar {
 	return s.setInt(mod.NewInt64(v, primeOrder))
 }
 
+func (s *scalar) SetIntString(v string) (kyber.Scalar, error) {
+	i, ok := new(big.Int).SetString(v, 0)
+	if !ok {
+		return nil, errors.New("invalid scalar string")
+	}
+	return s.setInt(mod.NewInt(i, primeOrder)), nil
+}
+
 func (s *scalar) toInt() *mod.Int {
 	return mod.NewIntBytes(s.v[:], primeOrder, defaultEndianess)
 }

--- a/group/mod/int.go
+++ b/group/mod/int.go
@@ -6,6 +6,7 @@ import (
 	"crypto/cipher"
 	"encoding/hex"
 	"errors"
+	"fmt"
 	"io"
 	"math/big"
 
@@ -171,6 +172,15 @@ func (i *Int) One() kyber.Scalar {
 func (i *Int) SetInt64(v int64) kyber.Scalar {
 	i.V.SetInt64(v).Mod(&i.V, i.M)
 	return i
+}
+
+func (i *Int) SetIntString(v string) (kyber.Scalar, error) {
+	bigV := new(big.Int)
+	bigV, ok := bigV.SetString(v, 0)
+	if !ok {
+		return nil, fmt.Errorf("unable to set string number: %v", v)
+	}
+	return i.Init(bigV, i.M), nil
 }
 
 // Int64 returns the int64 representation of the value.

--- a/pairing/bls12381/circl/scalar.go
+++ b/pairing/bls12381/circl/scalar.go
@@ -2,6 +2,7 @@ package circl
 
 import (
 	"crypto/cipher"
+	"fmt"
 	"io"
 	"math/big"
 
@@ -60,6 +61,14 @@ func (s *Scalar) SetInt64(v int64) kyber.Scalar {
 	}
 
 	return s
+}
+
+func (s *Scalar) SetIntString(v string) (kyber.Scalar, error) {
+	err := s.inner.SetString(v)
+	if err != nil {
+		return nil, fmt.Errorf("unable to set string number: %v", err)
+	}
+	return s, nil
 }
 
 func (s *Scalar) Zero() kyber.Scalar { s.inner.SetUint64(0); return s }


### PR DESCRIPTION
Hello all,

I added the method **SetIntString(v string) (Scalar, error)**  in the Scalar interface and implemented it on the structs that satisfy Scalar.

My reasoning was that I needed to use a Secret Sharing protocol and was having a fair bit of trouble creating a scalar with the value of the secret. In the vss_test.go tests, the secret is a random value, and there is a method just to create a random Scalar; however, to create a deterministic value, I either had to use SetInt64 or SetBytes.
With SetInt64, the number I set could have at most 64 bits.
With SetBytes, to generate a number I would have to pass its representation as a byte array. I found this hard to accomplish.

To make SetIntString I simply used big.Int's method to convert the string into a big.Int and then used what was already available to convert the big.Int into a Scalar.

I tested the changes in vss_test.go, function TestDeterministicStringSecret. It repeats tests that were already done but with an hardcoded secret instead of a random value.
I had to refactor the code a little to avoid repeating code, but nothing major. All tests are still running fine.

Thanks