### PR TITLE
Fix misleading comment in BN256 hashToPoint()

### DIFF
--- a/pairing/bn256/point.go
+++ b/pairing/bn256/point.go
@@ -263,7 +263,7 @@ func (p *pointG1) Hash(m []byte) kyber.Point {
 	return p
 }
 
-// hashes a byte slice into two points on a curve represented by big.Int
+// hashes a byte slice into a curve point represented by two big.Int's
 // ideally we want to do this using gfP, but gfP doesn't have a ModSqrt function
 func hashToPoint(m []byte) (*big.Int, *big.Int) {
 	h := sha256.Sum256(m)


### PR DESCRIPTION
Fix #450 