### PR TITLE
Add EDDSA test-vectors

### DIFF
--- a/internal/wycheproof/json_struct.go
+++ b/internal/wycheproof/json_struct.go
@@ -1,0 +1,117 @@
+package wycheproof
+
+type WycheProofTestV1 struct {
+	Algorithm        string   `json:"algorithm"`
+	Schema           string   `json:"schema"`
+	GeneratorVersion string   `json:"generatorVersion"`
+	NumberOfTest     int      `json:"numberOfTests"`
+	Header           []string `json:"header"`
+
+	Notes      NotesV1       `json:"notes"`
+	TestGroups []TestGroupV1 `json:"testGroups"`
+}
+
+type ResultV1 struct {
+	BugType     string
+	Description string
+	Effect      string
+}
+
+type NotesV1 struct {
+	CompressedSig   `json:"CompressedSignature"`
+	InvalidEncoding `json:"InvalidEncoding"`
+	InvalidKtv      `json:"InvalidKtv"`
+	InvalidSig      `json:"InvalidSignature"`
+	Ktv             `json:"Ktv"`
+	SigMalleability `json:"SignatureMalleability"`
+	TinkOverflow    `json:"TinkOverflow"`
+	TruncatedSig    `json:"TruncatedSignature"`
+	Valid           `json:"Valid"`
+}
+
+type CompressedSig struct {
+	BugType     string `json:"bugType"`
+	Description string `json:"description"`
+	Effect      string `json:"effect"`
+}
+
+type InvalidEncoding struct {
+	BugType     string `json:"bugType"`
+	Description string `json:"description"`
+	Effect      string `json:"effect"`
+}
+
+type InvalidKtv struct {
+	BugType     string `json:"bugType"`
+	Description string `json:"description"`
+}
+
+type InvalidSig struct {
+	BugType     string `json:"bugType"`
+	Description string `json:"description"`
+	Effect      string `json:"effect"`
+}
+
+type Ktv struct {
+	BugType     string `json:"bugType"`
+	Description string `json:"description"`
+}
+
+type SigMalleability struct {
+	BugType     string `json:"bugType"`
+	Description string `json:"description"`
+}
+
+type SigWithGarbage struct {
+	BugType     string `json:"bugType"`
+	Description string `json:"description"`
+}
+
+type TinkOverflow struct {
+	BugType     string `json:"bugType"`
+	Description string `json:"description"`
+}
+
+type TruncatedSig struct {
+	BugType     string `json:"bugType"`
+	Description string `json:"description"`
+	Effect      string `json:"effect"`
+}
+
+type Valid struct {
+	BugType     string `json:"bugType"`
+	Description string `json:"description"`
+}
+
+type TestGroupV1 struct {
+	Type  string         `json:"type"`
+	Pk    PublicKeyV1    `json:"publicKey"`
+	PkDer string         `json:"publicKeyDer"`
+	PkPem string         `json:"publicKeyPem"`
+	PkJwk PublicKeyJwkV1 `json:"publicKeyJwk"`
+
+	Tests []TestV1 `json:"tests"`
+}
+
+type PublicKeyV1 struct {
+	Type    string `json:"type"`
+	Curve   string `json:"curve"`
+	KeySize int    `json:"keySize"`
+	PK      string `json:"pk"`
+}
+
+type PublicKeyJwkV1 struct {
+	Kty string `json:"kty"`
+	Crv string `json:"crv"`
+	Kid string `json:"kid"`
+	X   string `json:"x"`
+}
+
+type TestV1 struct {
+	TcId    int      `json:"tcId"`
+	Comment string   `json:"comment"`
+	Flags   []string `json:"flags"`
+	Msg     string   `json:"msg"`
+	Sig     string   `json:"sig"`
+	Result  string   `json:"result"`
+}

--- a/internal/wycheproof/json_struct.go
+++ b/internal/wycheproof/json_struct.go
@@ -1,6 +1,6 @@
 package wycheproof
 
-type WycheProofTestV1 struct {
+type TestV1 struct {
 	Algorithm        string   `json:"algorithm"`
 	Schema           string   `json:"schema"`
 	GeneratorVersion string   `json:"generatorVersion"`
@@ -90,7 +90,7 @@ type TestGroupV1 struct {
 	PkPem string         `json:"publicKeyPem"`
 	PkJwk PublicKeyJwkV1 `json:"publicKeyJwk"`
 
-	Tests []TestV1 `json:"tests"`
+	Tests []Test `json:"tests"`
 }
 
 type PublicKeyV1 struct {
@@ -107,8 +107,8 @@ type PublicKeyJwkV1 struct {
 	X   string `json:"x"`
 }
 
-type TestV1 struct {
-	TcId    int      `json:"tcId"`
+type Test struct {
+	TcID    int      `json:"tcId"`
 	Comment string   `json:"comment"`
 	Flags   []string `json:"flags"`
 	Msg     string   `json:"msg"`

--- a/sign/eddsa/eddsa_test.go
+++ b/sign/eddsa/eddsa_test.go
@@ -6,12 +6,15 @@ import (
 	"compress/gzip"
 	"crypto/cipher"
 	"encoding/hex"
+	"encoding/json"
+	"io"
 	"math/rand"
 	"os"
 	"strings"
 	"testing"
 
 	"go.dedis.ch/kyber/v4/group/edwards25519"
+	"go.dedis.ch/kyber/v4/internal/wycheproof"
 	"go.dedis.ch/kyber/v4/util/random"
 
 	"github.com/stretchr/testify/assert"
@@ -345,5 +348,47 @@ func TestGolden(t *testing.T) {
 
 	if err := scanner.Err(); err != nil {
 		t.Fatalf("error reading test data: %s", err)
+	}
+}
+
+// Test vectors from: https://github.com/C2SP/wycheproof/blob/master/testvectors_v1/ed25519_test.json
+func TestWycheProof(t *testing.T) {
+	// Open Json and parse content
+	jsonFile, err := os.Open("testdata/ed25519_test.json")
+	require.NoError(t, err)
+	defer jsonFile.Close()
+
+	jsonByte, err := io.ReadAll(jsonFile)
+	require.NoError(t, err)
+
+	var wycheproofTestData wycheproof.WycheProofTestV1
+	err = json.Unmarshal(jsonByte, &wycheproofTestData)
+	require.NoError(t, err)
+
+	// Prepare instance
+	suite := edwards25519.NewBlakeSHA256Ed25519()
+	pk := suite.Point()
+
+	// Go over every tests
+	for _, testGroup := range wycheproofTestData.TestGroups {
+		pkBytes, err := hex.DecodeString(testGroup.Pk.PK)
+		require.NoError(t, err)
+
+		err = pk.UnmarshalBinary(pkBytes)
+		require.NoError(t, err)
+
+		for _, test := range testGroup.Tests {
+			sigByte, err := hex.DecodeString(test.Sig)
+			require.NoError(t, err)
+			msgByte, err := hex.DecodeString(test.Msg)
+			require.NoError(t, err)
+			err = Verify(pk, msgByte, sigByte)
+
+			if test.Result == "valid" {
+				require.NoError(t, err)
+			} else {
+				require.NotNil(t, err)
+			}
+		}
 	}
 }

--- a/sign/eddsa/eddsa_test.go
+++ b/sign/eddsa/eddsa_test.go
@@ -361,7 +361,7 @@ func TestWycheProof(t *testing.T) {
 	jsonByte, err := io.ReadAll(jsonFile)
 	require.NoError(t, err)
 
-	var wycheproofTestData wycheproof.WycheProofTestV1
+	var wycheproofTestData wycheproof.TestV1
 	err = json.Unmarshal(jsonByte, &wycheproofTestData)
 	require.NoError(t, err)
 

--- a/sign/eddsa/eddsa_test.go
+++ b/sign/eddsa/eddsa_test.go
@@ -351,7 +351,7 @@ func TestGolden(t *testing.T) {
 	}
 }
 
-// Test vectors from: https://github.com/C2SP/wycheproof/blob/master/testvectors_v1/ed25519_test.json
+// Test vectors from: https://github.com/C2SP/wycheproof/blob/0d2dab394df1eb05b0865977f7633d010a98bccd/testvectors_v1/ed25519_test.json
 func TestWycheProof(t *testing.T) {
 	// Open Json and parse content
 	jsonFile, err := os.Open("testdata/ed25519_test.json")

--- a/sign/eddsa/testdata/LICENSE
+++ b/sign/eddsa/testdata/LICENSE
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/sign/eddsa/testdata/README.md
+++ b/sign/eddsa/testdata/README.md
@@ -1,0 +1,5 @@
+### Wycheproof eddsa test vectors
+
+The json file was taken from: https://github.com/C2SP/wycheproof/blob/0d2dab394df1eb05b0865977f7633d010a98bccd/testvectors_v1/ed25519_test.json
+
+This test data is under [Apache License 2.0](./LICENSE), complete license in the `LICENSE` file in this directory.

--- a/sign/eddsa/testdata/ed25519_test.json
+++ b/sign/eddsa/testdata/ed25519_test.json
@@ -1,0 +1,3020 @@
+{
+  "algorithm" : "EDDSA",
+  "schema" : "eddsa_verify_schema.json",
+  "generatorVersion" : "0.9rc5",
+  "numberOfTests" : 150,
+  "header" : [
+    "Test vectors of type EddsaVerify are intended for testing"
+  ],
+  "notes" : {
+    "CompressedSignature" : {
+      "bugType" : "CAN_OF_WORMS",
+      "description" : "The test vector contains a signature where r and s overlap or where 0 bytes were cut from the signature. This signature was specifically generated.",
+      "effect" : "The effect of the bug is unclear without further analysis. It could be rather benign and just allow signature malleability in some cases or it could hide a more severe flaw."
+    },
+    "InvalidEncoding" : {
+      "bugType" : "CAN_OF_WORMS",
+      "description" : "The test vector contains a signature with an invalid encoding of the values. The vector checks that invalid encodings are not accepted.",
+      "effect" : "The effect of accepting such signatures is unclear. It could lead to signature malleability, be benign, or hide something more severe."
+    },
+    "InvalidKtv" : {
+      "bugType" : "UNKNOWN",
+      "description" : "The test vector contains a known invalid signature."
+    },
+    "InvalidSignature" : {
+      "bugType" : "AUTH_BYPASS",
+      "description" : "The test vector contains a signature with edge case values such as 0 or the order of the group.",
+      "effect" : "The effect of accepting such signatures probably indicates that signatures can be forged without even knowing the message itself."
+    },
+    "Ktv" : {
+      "bugType" : "BASIC",
+      "description" : "The test vector contains a known valid signature."
+    },
+    "SignatureMalleability" : {
+      "bugType" : "SIGNATURE_MALLEABILITY",
+      "description" : "EdDSA signatures are non-malleable, if implemented correctly. If an implementation fails to check the range of S then it may be possible to modify a signature in such a way that it still verifies. See RFC 8032, Section 5.2.7 and Section 8.4."
+    },
+    "SignatureWithGarbage" : {
+      "bugType" : "SIGNATURE_MALLEABILITY",
+      "description" : "The test vector contains a signature with additional content. EdDSA signature are expected to be non-malleable. Signatures of the wrong length should be rejected. See RFC 8032, Section 5.2.7 and Section 8.4."
+    },
+    "TinkOverflow" : {
+      "bugType" : "KNOWN_BUG",
+      "description" : "The test vector contains a signature that caused an arithmetic overflow in tink."
+    },
+    "TruncatedSignature" : {
+      "bugType" : "AUTH_BYPASS",
+      "description" : "The test vector contains a signature that was truncated.",
+      "effect" : "Accepting such signatures likely means that signatures can be forged."
+    },
+    "Valid" : {
+      "bugType" : "BASIC",
+      "description" : "The test vector is an ordinary valid signature."
+    }
+  },
+  "testGroups" : [
+    {
+      "type" : "EddsaVerify",
+      "publicKey" : {
+        "type" : "EDDSAPublicKey",
+        "curve" : "edwards25519",
+        "keySize" : 255,
+        "pk" : "7d4d0e7f6153a69b6242b522abbee685fda4420f8834b108c3bdae369ef549fa"
+      },
+      "publicKeyDer" : "302a300506032b65700321007d4d0e7f6153a69b6242b522abbee685fda4420f8834b108c3bdae369ef549fa",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMCowBQYDK2VwAyEAfU0Of2FTpptiQrUiq77mhf2kQg+INLEIw72uNp71Sfo=\n-----END PUBLIC KEY-----\n",
+      "publicKeyJwk" : {
+        "kty" : "OKP",
+        "crv" : "Ed25519",
+        "kid" : "none",
+        "x" : "fU0Of2FTpptiQrUiq77mhf2kQg-INLEIw72uNp71Sfo"
+      },
+      "tests" : [
+        {
+          "tcId" : 1,
+          "comment" : "",
+          "flags" : [
+            "Valid"
+          ],
+          "msg" : "",
+          "sig" : "d4fbdb52bfa726b44d1786a8c0d171c3e62ca83c9e5bbe63de0bb2483f8fd6cc1429ab72cafc41ab56af02ff8fcc43b99bfe4c7ae940f60f38ebaa9d311c4007",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 2,
+          "comment" : "",
+          "flags" : [
+            "Valid"
+          ],
+          "msg" : "78",
+          "sig" : "d80737358ede548acb173ef7e0399f83392fe8125b2ce877de7975d8b726ef5b1e76632280ee38afad12125ea44b961bf92f1178c9fa819d020869975bcbe109",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 3,
+          "comment" : "",
+          "flags" : [
+            "Valid"
+          ],
+          "msg" : "54657374",
+          "sig" : "7c38e026f29e14aabd059a0f2db8b0cd783040609a8be684db12f82a27774ab07a9155711ecfaf7f99f277bad0c6ae7e39d4eef676573336a5c51eb6f946b30d",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 4,
+          "comment" : "",
+          "flags" : [
+            "Valid"
+          ],
+          "msg" : "48656c6c6f",
+          "sig" : "1c1ad976cbaae3b31dee07971cf92c928ce2091a85f5899f5e11ecec90fc9f8e93df18c5037ec9b29c07195ad284e63d548cd0a6fe358cc775bd6c1608d2c905",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 5,
+          "comment" : "",
+          "flags" : [
+            "Valid"
+          ],
+          "msg" : "313233343030",
+          "sig" : "657c1492402ab5ce03e2c3a7f0384d051b9cf3570f1207fc78c1bcc98c281c2bf0cf5b3a289976458a1be6277a5055545253b45b07dcc1abd96c8b989c00f301",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 6,
+          "comment" : "",
+          "flags" : [
+            "Valid"
+          ],
+          "msg" : "000000000000000000000000",
+          "sig" : "d46543bfb892f84ec124dcdfc847034c19363bf3fc2fa89b1267833a14856e52e60736918783f950b6f1dd8d40dc343247cd43ce054c2d68ef974f7ed0f3c60f",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 7,
+          "comment" : "",
+          "flags" : [
+            "Valid"
+          ],
+          "msg" : "6161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161",
+          "sig" : "879350045543bc14ed2c08939b68c30d22251d83e018cacbaf0c9d7a48db577e80bdf76ce99e5926762bc13b7b3483260a5ef63d07e34b58eb9c14621ac92f00",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 8,
+          "comment" : "",
+          "flags" : [
+            "Valid"
+          ],
+          "msg" : "202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f404142434445464748494a4b4c4d4e4f505152535455565758595a5b5c5d5e5f60",
+          "sig" : "7bdc3f9919a05f1d5db4a3ada896094f6871c1f37afc75db82ec3147d84d6f237b7e5ecc26b59cfea0c7eaf1052dc427b0f724615be9c3d3e01356c65b9b5109",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 9,
+          "comment" : "",
+          "flags" : [
+            "Valid"
+          ],
+          "msg" : "ffffffffffffffffffffffffffffffff",
+          "sig" : "5dbd7360e55aa38e855d6ad48c34bd35b7871628508906861a7c4776765ed7d1e13d910faabd689ec8618b78295c8ab8f0e19c8b4b43eb8685778499e943ae04",
+          "result" : "valid"
+        }
+      ]
+    },
+    {
+      "type" : "EddsaVerify",
+      "publicKey" : {
+        "type" : "EDDSAPublicKey",
+        "curve" : "edwards25519",
+        "keySize" : 255,
+        "pk" : "7d4d0e7f6153a69b6242b522abbee685fda4420f8834b108c3bdae369ef549fa"
+      },
+      "publicKeyDer" : "302a300506032b65700321007d4d0e7f6153a69b6242b522abbee685fda4420f8834b108c3bdae369ef549fa",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMCowBQYDK2VwAyEAfU0Of2FTpptiQrUiq77mhf2kQg+INLEIw72uNp71Sfo=\n-----END PUBLIC KEY-----\n",
+      "publicKeyJwk" : {
+        "kty" : "OKP",
+        "crv" : "Ed25519",
+        "kid" : "none",
+        "x" : "fU0Of2FTpptiQrUiq77mhf2kQg-INLEIw72uNp71Sfo"
+      },
+      "tests" : [
+        {
+          "tcId" : 10,
+          "comment" : "special values for r and s",
+          "flags" : [
+            "InvalidSignature"
+          ],
+          "msg" : "3f",
+          "sig" : "00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 11,
+          "comment" : "special values for r and s",
+          "flags" : [
+            "InvalidSignature"
+          ],
+          "msg" : "3f",
+          "sig" : "00000000000000000000000000000000000000000000000000000000000000000100000000000000000000000000000000000000000000000000000000000000",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 12,
+          "comment" : "special values for r and s",
+          "flags" : [
+            "InvalidSignature"
+          ],
+          "msg" : "3f",
+          "sig" : "0000000000000000000000000000000000000000000000000000000000000000ecd3f55c1a631258d69cf7a2def9de1400000000000000000000000000000010",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 13,
+          "comment" : "special values for r and s",
+          "flags" : [
+            "InvalidSignature"
+          ],
+          "msg" : "3f",
+          "sig" : "0000000000000000000000000000000000000000000000000000000000000000edd3f55c1a631258d69cf7a2def9de1400000000000000000000000000000010",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 14,
+          "comment" : "special values for r and s",
+          "flags" : [
+            "InvalidSignature"
+          ],
+          "msg" : "3f",
+          "sig" : "0000000000000000000000000000000000000000000000000000000000000000edffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff7f",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 15,
+          "comment" : "special values for r and s",
+          "flags" : [
+            "InvalidSignature"
+          ],
+          "msg" : "3f",
+          "sig" : "01000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 16,
+          "comment" : "special values for r and s",
+          "flags" : [
+            "InvalidSignature"
+          ],
+          "msg" : "3f",
+          "sig" : "01000000000000000000000000000000000000000000000000000000000000000100000000000000000000000000000000000000000000000000000000000000",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 17,
+          "comment" : "special values for r and s",
+          "flags" : [
+            "InvalidSignature"
+          ],
+          "msg" : "3f",
+          "sig" : "0100000000000000000000000000000000000000000000000000000000000000ecd3f55c1a631258d69cf7a2def9de1400000000000000000000000000000010",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 18,
+          "comment" : "special values for r and s",
+          "flags" : [
+            "InvalidSignature"
+          ],
+          "msg" : "3f",
+          "sig" : "0100000000000000000000000000000000000000000000000000000000000000edd3f55c1a631258d69cf7a2def9de1400000000000000000000000000000010",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 19,
+          "comment" : "special values for r and s",
+          "flags" : [
+            "InvalidSignature"
+          ],
+          "msg" : "3f",
+          "sig" : "0100000000000000000000000000000000000000000000000000000000000000edffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff7f",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 20,
+          "comment" : "special values for r and s",
+          "flags" : [
+            "InvalidSignature"
+          ],
+          "msg" : "3f",
+          "sig" : "edd3f55c1a631258d69cf7a2def9de14000000000000000000000000000000100000000000000000000000000000000000000000000000000000000000000000",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 21,
+          "comment" : "special values for r and s",
+          "flags" : [
+            "InvalidSignature"
+          ],
+          "msg" : "3f",
+          "sig" : "edd3f55c1a631258d69cf7a2def9de14000000000000000000000000000000100100000000000000000000000000000000000000000000000000000000000000",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 22,
+          "comment" : "special values for r and s",
+          "flags" : [
+            "InvalidSignature"
+          ],
+          "msg" : "3f",
+          "sig" : "edd3f55c1a631258d69cf7a2def9de1400000000000000000000000000000010ecd3f55c1a631258d69cf7a2def9de1400000000000000000000000000000010",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 23,
+          "comment" : "special values for r and s",
+          "flags" : [
+            "InvalidSignature"
+          ],
+          "msg" : "3f",
+          "sig" : "edd3f55c1a631258d69cf7a2def9de1400000000000000000000000000000010edd3f55c1a631258d69cf7a2def9de1400000000000000000000000000000010",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 24,
+          "comment" : "special values for r and s",
+          "flags" : [
+            "InvalidSignature"
+          ],
+          "msg" : "3f",
+          "sig" : "edd3f55c1a631258d69cf7a2def9de1400000000000000000000000000000010edffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff7f",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 25,
+          "comment" : "special values for r and s",
+          "flags" : [
+            "InvalidSignature"
+          ],
+          "msg" : "3f",
+          "sig" : "edffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff7f0000000000000000000000000000000000000000000000000000000000000000",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 26,
+          "comment" : "special values for r and s",
+          "flags" : [
+            "InvalidSignature"
+          ],
+          "msg" : "3f",
+          "sig" : "edffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff7f0100000000000000000000000000000000000000000000000000000000000000",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 27,
+          "comment" : "special values for r and s",
+          "flags" : [
+            "InvalidSignature"
+          ],
+          "msg" : "3f",
+          "sig" : "edffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff7fecd3f55c1a631258d69cf7a2def9de1400000000000000000000000000000010",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 28,
+          "comment" : "special values for r and s",
+          "flags" : [
+            "InvalidSignature"
+          ],
+          "msg" : "3f",
+          "sig" : "edffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff7fedd3f55c1a631258d69cf7a2def9de1400000000000000000000000000000010",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 29,
+          "comment" : "special values for r and s",
+          "flags" : [
+            "InvalidSignature"
+          ],
+          "msg" : "3f",
+          "sig" : "edffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff7fedffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff7f",
+          "result" : "invalid"
+        }
+      ]
+    },
+    {
+      "type" : "EddsaVerify",
+      "publicKey" : {
+        "type" : "EDDSAPublicKey",
+        "curve" : "edwards25519",
+        "keySize" : 255,
+        "pk" : "7d4d0e7f6153a69b6242b522abbee685fda4420f8834b108c3bdae369ef549fa"
+      },
+      "publicKeyDer" : "302a300506032b65700321007d4d0e7f6153a69b6242b522abbee685fda4420f8834b108c3bdae369ef549fa",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMCowBQYDK2VwAyEAfU0Of2FTpptiQrUiq77mhf2kQg+INLEIw72uNp71Sfo=\n-----END PUBLIC KEY-----\n",
+      "publicKeyJwk" : {
+        "kty" : "OKP",
+        "crv" : "Ed25519",
+        "kid" : "none",
+        "x" : "fU0Of2FTpptiQrUiq77mhf2kQg-INLEIw72uNp71Sfo"
+      },
+      "tests" : [
+        {
+          "tcId" : 30,
+          "comment" : "empty signature",
+          "flags" : [
+            "TruncatedSignature"
+          ],
+          "msg" : "54657374",
+          "sig" : "",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 31,
+          "comment" : "s missing",
+          "flags" : [
+            "TruncatedSignature"
+          ],
+          "msg" : "54657374",
+          "sig" : "7c38e026f29e14aabd059a0f2db8b0cd783040609a8be684db12f82a27774ab0",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 32,
+          "comment" : "signature too short",
+          "flags" : [
+            "TruncatedSignature"
+          ],
+          "msg" : "54657374",
+          "sig" : "7c38e026f29e14aabd059a0f2db8b0cd783040609a8be684db12f82a27774ab07a9155711ecfaf7f99f277bad0c6ae7e39d4eef676573336a5c51eb6f946",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 33,
+          "comment" : "signature too long",
+          "flags" : [
+            "SignatureWithGarbage"
+          ],
+          "msg" : "54657374",
+          "sig" : "7c38e026f29e14aabd059a0f2db8b0cd783040609a8be684db12f82a27774ab07a9155711ecfaf7f99f277bad0c6ae7e39d4eef676573336a5c51eb6f946b30d2020",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 34,
+          "comment" : "include pk in signature",
+          "flags" : [
+            "SignatureWithGarbage"
+          ],
+          "msg" : "54657374",
+          "sig" : "7c38e026f29e14aabd059a0f2db8b0cd783040609a8be684db12f82a27774ab07a9155711ecfaf7f99f277bad0c6ae7e39d4eef676573336a5c51eb6f946b30d7d4d0e7f6153a69b6242b522abbee685fda4420f8834b108c3bdae369ef549fa",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 35,
+          "comment" : "prepending 0 byte to signature",
+          "flags" : [
+            "SignatureWithGarbage"
+          ],
+          "msg" : "54657374",
+          "sig" : "007c38e026f29e14aabd059a0f2db8b0cd783040609a8be684db12f82a27774ab07a9155711ecfaf7f99f277bad0c6ae7e39d4eef676573336a5c51eb6f946b30d",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 36,
+          "comment" : "prepending 0 byte to s",
+          "flags" : [
+            "SignatureWithGarbage"
+          ],
+          "msg" : "54657374",
+          "sig" : "7c38e026f29e14aabd059a0f2db8b0cd783040609a8be684db12f82a27774ab0007a9155711ecfaf7f99f277bad0c6ae7e39d4eef676573336a5c51eb6f946b30d",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 37,
+          "comment" : "appending 0 byte to signature",
+          "flags" : [
+            "SignatureWithGarbage"
+          ],
+          "msg" : "54657374",
+          "sig" : "7c38e026f29e14aabd059a0f2db8b0cd783040609a8be684db12f82a27774ab07a9155711ecfaf7f99f277bad0c6ae7e39d4eef676573336a5c51eb6f946b30d00",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 38,
+          "comment" : "removing 0 byte from signature",
+          "flags" : [
+            "CompressedSignature"
+          ],
+          "msg" : "546573743137",
+          "sig" : "93de3ca252426c95f735cb9edd92e83321ac62372d5aa5b379786bae111ab6b17251330e8f9a7c30d6993137c596007d7b001409287535ac4804e662bc58a3",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 39,
+          "comment" : "removing 0 byte from signature",
+          "flags" : [
+            "CompressedSignature"
+          ],
+          "msg" : "54657374313236",
+          "sig" : "dffed33a7f420b62bb1731cfd03be805affd18a281ec02b1067ba6e9d20826569e742347df59c88ae96db1f1969fb189b0ec34381d85633e1889da48d95e0e",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 40,
+          "comment" : "removing leading 0 byte from signature",
+          "flags" : [
+            "CompressedSignature"
+          ],
+          "msg" : "546573743530",
+          "sig" : "6e170c719577c25e0e1e8b8aa7a6346f8b109f37385cc2e85dc3b4c0f46a9c6bcafd67f52324c5dbaf40a1b673fb29c4a56052d2d6999d0838a8337bccb502",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 41,
+          "comment" : "dropping byte from signature",
+          "flags" : [
+            "CompressedSignature"
+          ],
+          "msg" : "54657374333437",
+          "sig" : "b0928b46e99fbbad3f5cb502d2cd309d94a7e86cfd4d84b1fcf4cea18075a9c36993c0582dba1e9e519fae5a8654f454201ae0c3cb397c37b8f4f8eef18400",
+          "result" : "invalid"
+        }
+      ]
+    },
+    {
+      "type" : "EddsaVerify",
+      "publicKey" : {
+        "type" : "EDDSAPublicKey",
+        "curve" : "edwards25519",
+        "keySize" : 255,
+        "pk" : "7d4d0e7f6153a69b6242b522abbee685fda4420f8834b108c3bdae369ef549fa"
+      },
+      "publicKeyDer" : "302a300506032b65700321007d4d0e7f6153a69b6242b522abbee685fda4420f8834b108c3bdae369ef549fa",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMCowBQYDK2VwAyEAfU0Of2FTpptiQrUiq77mhf2kQg+INLEIw72uNp71Sfo=\n-----END PUBLIC KEY-----\n",
+      "publicKeyJwk" : {
+        "kty" : "OKP",
+        "crv" : "Ed25519",
+        "kid" : "none",
+        "x" : "fU0Of2FTpptiQrUiq77mhf2kQg-INLEIw72uNp71Sfo"
+      },
+      "tests" : [
+        {
+          "tcId" : 42,
+          "comment" : "modified bit 0 in R",
+          "flags" : [
+            "InvalidEncoding"
+          ],
+          "msg" : "313233343030",
+          "sig" : "647c1492402ab5ce03e2c3a7f0384d051b9cf3570f1207fc78c1bcc98c281c2b1d125e5538f38afbcc1c84e489521083041d24bc6240767029da063271a1ff0c",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 43,
+          "comment" : "modified bit 1 in R",
+          "flags" : [
+            "InvalidEncoding"
+          ],
+          "msg" : "313233343030",
+          "sig" : "677c1492402ab5ce03e2c3a7f0384d051b9cf3570f1207fc78c1bcc98c281c2bc108ca4b87a49c9ed2cf383aecad8f54a962b2899da891e12004d7993a627e01",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 44,
+          "comment" : "modified bit 2 in R",
+          "flags" : [
+            "InvalidEncoding"
+          ],
+          "msg" : "313233343030",
+          "sig" : "617c1492402ab5ce03e2c3a7f0384d051b9cf3570f1207fc78c1bcc98c281c2b9ce23fc6213ed5b87912e9bbf92f5e2c780eae26d15c50a112d1e97d2ea33c06",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 45,
+          "comment" : "modified bit 7 in R",
+          "flags" : [
+            "InvalidEncoding"
+          ],
+          "msg" : "313233343030",
+          "sig" : "e57c1492402ab5ce03e2c3a7f0384d051b9cf3570f1207fc78c1bcc98c281c2bbb3eb51cd98dddb235a5f46f2bded6af184a58d09cce928bda43f41d69118a03",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 46,
+          "comment" : "modified bit 8 in R",
+          "flags" : [
+            "InvalidEncoding"
+          ],
+          "msg" : "313233343030",
+          "sig" : "657d1492402ab5ce03e2c3a7f0384d051b9cf3570f1207fc78c1bcc98c281c2bcd237dda9a116501f67a5705a854b9adc304f34720803a91b324f2c13e0f5a09",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 47,
+          "comment" : "modified bit 16 in R",
+          "flags" : [
+            "InvalidEncoding"
+          ],
+          "msg" : "313233343030",
+          "sig" : "657c1592402ab5ce03e2c3a7f0384d051b9cf3570f1207fc78c1bcc98c281c2b6b167bbdc0d881cc04d28905552c1876f3709851abc5007376940cc8a435c300",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 48,
+          "comment" : "modified bit 31 in R",
+          "flags" : [
+            "InvalidEncoding"
+          ],
+          "msg" : "313233343030",
+          "sig" : "657c1412402ab5ce03e2c3a7f0384d051b9cf3570f1207fc78c1bcc98c281c2b7fd2ac7da14afffcceeb13f2a0d6b887941cb1a5eb57a52f3cb131a16cce7b0e",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 49,
+          "comment" : "modified bit 32 in R",
+          "flags" : [
+            "InvalidEncoding"
+          ],
+          "msg" : "313233343030",
+          "sig" : "657c1492412ab5ce03e2c3a7f0384d051b9cf3570f1207fc78c1bcc98c281c2b7373ba13ebbef99cd2a8ead55ce735c987d85a35320925a8e871702dc7c5c40d",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 50,
+          "comment" : "modified bit 63 in R",
+          "flags" : [
+            "InvalidEncoding"
+          ],
+          "msg" : "313233343030",
+          "sig" : "657c1492402ab54e03e2c3a7f0384d051b9cf3570f1207fc78c1bcc98c281c2bd35bd331c03f0855504ca1cab87b83c36a028425a3cf007ede4f4254c261cb00",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 51,
+          "comment" : "modified bit 64 in R",
+          "flags" : [
+            "InvalidEncoding"
+          ],
+          "msg" : "313233343030",
+          "sig" : "657c1492402ab5ce02e2c3a7f0384d051b9cf3570f1207fc78c1bcc98c281c2bcb35101f73cf467deac8c1a03b6c3dc35af544132734b7e57ab20c89b2e4750d",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 52,
+          "comment" : "modified bit 97 in R",
+          "flags" : [
+            "InvalidEncoding"
+          ],
+          "msg" : "313233343030",
+          "sig" : "657c1492402ab5ce03e2c3a7f2384d051b9cf3570f1207fc78c1bcc98c281c2bb58d2e8878290bff8d3355fdd4ea381924ee578752354eb6dee678ab4011c301",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 53,
+          "comment" : "modified bit 127 in R",
+          "flags" : [
+            "InvalidEncoding"
+          ],
+          "msg" : "313233343030",
+          "sig" : "657c1492402ab5ce03e2c3a7f0384d851b9cf3570f1207fc78c1bcc98c281c2bb978c866187ffb1cc7b29a0b4045aefc08768df65717194ff0c6e63f4dea0d02",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 54,
+          "comment" : "modified bit 240 in R",
+          "flags" : [
+            "InvalidEncoding"
+          ],
+          "msg" : "313233343030",
+          "sig" : "657c1492402ab5ce03e2c3a7f0384d051b9cf3570f1207fc78c1bcc98c281d2b0576ecf8eaf675f00f3dfbe19f75b83b7607a6c96414f6821af920a2498d0305",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 55,
+          "comment" : "modified bit 247 in R",
+          "flags" : [
+            "InvalidEncoding"
+          ],
+          "msg" : "313233343030",
+          "sig" : "657c1492402ab5ce03e2c3a7f0384d051b9cf3570f1207fc78c1bcc98c289c2be5241a345c7b5428054c74b7c382fa10d4a5f1e8f8b79a71d3fdea2254f1ff0e",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 56,
+          "comment" : "modified bit 248 in R",
+          "flags" : [
+            "InvalidEncoding"
+          ],
+          "msg" : "313233343030",
+          "sig" : "657c1492402ab5ce03e2c3a7f0384d051b9cf3570f1207fc78c1bcc98c281c2a63950c85cd6dc96364e768de50ff7732b538f8a0b1615d799190ab600849230e",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 57,
+          "comment" : "modified bit 253 in R",
+          "flags" : [
+            "InvalidEncoding"
+          ],
+          "msg" : "313233343030",
+          "sig" : "657c1492402ab5ce03e2c3a7f0384d051b9cf3570f1207fc78c1bcc98c281c0b543bd3da0a56a8c9c152f59c9fec12f31fa66434d48b817b30d90cb4efa8b501",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 58,
+          "comment" : "modified bit 254 in R",
+          "flags" : [
+            "InvalidEncoding"
+          ],
+          "msg" : "313233343030",
+          "sig" : "657c1492402ab5ce03e2c3a7f0384d051b9cf3570f1207fc78c1bcc98c281c6b8da07efd07a6dafb015ed6a32fe136319a972ffbc341f3a0beae97ccf8136505",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 59,
+          "comment" : "modified bit 255 in R",
+          "flags" : [
+            "InvalidEncoding"
+          ],
+          "msg" : "313233343030",
+          "sig" : "657c1492402ab5ce03e2c3a7f0384d051b9cf3570f1207fc78c1bcc98c281cab227aedf259f910f0f3a759a335062665217925d019173b88917eae294f75d40f",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 60,
+          "comment" : "R==0",
+          "flags" : [
+            "InvalidEncoding"
+          ],
+          "msg" : "313233343030",
+          "sig" : "0000000000000000000000000000000000000000000000000000000000000000e0b8e7770d51c7a36375d006c5bffd6af43ff54aaf47e4330dc118c71d61ec02",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 61,
+          "comment" : "invalid R",
+          "flags" : [
+            "InvalidEncoding"
+          ],
+          "msg" : "313233343030",
+          "sig" : "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff463a1908382e7eb7693acef9884f7cf931a215e0791876be22c631a59881fd0e",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 62,
+          "comment" : "all bits flipped in R",
+          "flags" : [
+            "InvalidEncoding"
+          ],
+          "msg" : "313233343030",
+          "sig" : "9a83eb6dbfd54a31fc1d3c580fc7b2fae4630ca8f0edf803873e433673d7e3d40e94254586cb6188c5386c3febed477cb9a6cb29e3979adc4cb27cf5278fb70a",
+          "result" : "invalid"
+        }
+      ]
+    },
+    {
+      "type" : "EddsaVerify",
+      "publicKey" : {
+        "type" : "EDDSAPublicKey",
+        "curve" : "edwards25519",
+        "keySize" : 255,
+        "pk" : "7d4d0e7f6153a69b6242b522abbee685fda4420f8834b108c3bdae369ef549fa"
+      },
+      "publicKeyDer" : "302a300506032b65700321007d4d0e7f6153a69b6242b522abbee685fda4420f8834b108c3bdae369ef549fa",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMCowBQYDK2VwAyEAfU0Of2FTpptiQrUiq77mhf2kQg+INLEIw72uNp71Sfo=\n-----END PUBLIC KEY-----\n",
+      "publicKeyJwk" : {
+        "kty" : "OKP",
+        "crv" : "Ed25519",
+        "kid" : "none",
+        "x" : "fU0Of2FTpptiQrUiq77mhf2kQg-INLEIw72uNp71Sfo"
+      },
+      "tests" : [
+        {
+          "tcId" : 63,
+          "comment" : "checking malleability ",
+          "flags" : [
+            "SignatureMalleability"
+          ],
+          "msg" : "54657374",
+          "sig" : "7c38e026f29e14aabd059a0f2db8b0cd783040609a8be684db12f82a27774ab067654bce3832c2d76f8f6f5dafc08d9339d4eef676573336a5c51eb6f946b31d",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 64,
+          "comment" : "checking malleability ",
+          "flags" : [
+            "SignatureMalleability"
+          ],
+          "msg" : "54657374",
+          "sig" : "7c38e026f29e14aabd059a0f2db8b0cd783040609a8be684db12f82a27774ab05439412b5395d42f462c67008eba6ca839d4eef676573336a5c51eb6f946b32d",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 65,
+          "comment" : "checking malleability ",
+          "flags" : [
+            "SignatureMalleability"
+          ],
+          "msg" : "54657374",
+          "sig" : "7c38e026f29e14aabd059a0f2db8b0cd783040609a8be684db12f82a27774ab02ee12ce5875bf9dff26556464bae2ad239d4eef676573336a5c51eb6f946b34d",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 66,
+          "comment" : "checking malleability ",
+          "flags" : [
+            "SignatureMalleability"
+          ],
+          "msg" : "54657374",
+          "sig" : "7c38e026f29e14aabd059a0f2db8b0cd783040609a8be684db12f82a27774ab0e2300459f1e742404cd934d2c595a6253ad4eef676573336a5c51eb6f946b38d",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 67,
+          "comment" : "checking malleability ",
+          "flags" : [
+            "SignatureMalleability"
+          ],
+          "msg" : "54657374",
+          "sig" : "7c38e026f29e14aabd059a0f2db8b0cd783040609a8be684db12f82a27774ab07a9155711ecfaf7f99f277bad0c6ae7e39d4eef676573336a5c51eb6f946b32d",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 68,
+          "comment" : "checking malleability ",
+          "flags" : [
+            "SignatureMalleability"
+          ],
+          "msg" : "54657374",
+          "sig" : "7c38e026f29e14aabd059a0f2db8b0cd783040609a8be684db12f82a27774ab07a9155711ecfaf7f99f277bad0c6ae7e39d4eef676573336a5c51eb6f946b34d",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 69,
+          "comment" : "checking malleability ",
+          "flags" : [
+            "SignatureMalleability"
+          ],
+          "msg" : "54657374",
+          "sig" : "7c38e026f29e14aabd059a0f2db8b0cd783040609a8be684db12f82a27774ab07a9155711ecfaf7f99f277bad0c6ae7e39d4eef676573336a5c51eb6f946b38d",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 70,
+          "comment" : "checking malleability ",
+          "flags" : [
+            "SignatureMalleability"
+          ],
+          "msg" : "54657374",
+          "sig" : "7c38e026f29e14aabd059a0f2db8b0cd783040609a8be684db12f82a27774ab0679155711ecfaf7f99f277bad0c6ae7e39d4eef676573336a5c51eb6f946b38d",
+          "result" : "invalid"
+        }
+      ]
+    },
+    {
+      "type" : "EddsaVerify",
+      "publicKey" : {
+        "type" : "EDDSAPublicKey",
+        "curve" : "edwards25519",
+        "keySize" : 255,
+        "pk" : "a12c2beb77265f2aac953b5009349d94155a03ada416aad451319480e983ca4c"
+      },
+      "publicKeyDer" : "302a300506032b6570032100a12c2beb77265f2aac953b5009349d94155a03ada416aad451319480e983ca4c",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMCowBQYDK2VwAyEAoSwr63cmXyqslTtQCTSdlBVaA62kFqrUUTGUgOmDykw=\n-----END PUBLIC KEY-----\n",
+      "publicKeyJwk" : {
+        "kty" : "OKP",
+        "crv" : "Ed25519",
+        "kid" : "none",
+        "x" : "oSwr63cmXyqslTtQCTSdlBVaA62kFqrUUTGUgOmDykw"
+      },
+      "tests" : [
+        {
+          "tcId" : 71,
+          "comment" : "",
+          "flags" : [
+            "Valid"
+          ],
+          "msg" : "",
+          "sig" : "5056325d2ab440bf30bbf0f7173199aa8b4e6fbc091cf3eb6bc6cf87cd73d992ffc216c85e4ab5b8a0bbc7e9a6e9f8d33b7f6e5ac0ffdc22d9fcaf784af84302",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 72,
+          "comment" : "",
+          "flags" : [
+            "Valid"
+          ],
+          "msg" : "78",
+          "sig" : "481fafbf4364d7b682475282f517a3ac0538c9a6b6a562e99a3d8e5afb4f90a559b056b9f07af023905753b02d95eb329a35c77f154b79abbcd291615ce42f02",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 73,
+          "comment" : "",
+          "flags" : [
+            "Valid"
+          ],
+          "msg" : "54657374",
+          "sig" : "8a9bb4c465a3863abc9fd0dd35d80bb28f7d33d37d74679802d63f82b20da114b8d765a1206b3e9ad7cf2b2d8d778bb8651f1fa992db293c0039eacb6161480f",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 74,
+          "comment" : "",
+          "flags" : [
+            "Valid"
+          ],
+          "msg" : "48656c6c6f",
+          "sig" : "d839c20abfda1fd429531831c64f813f84b913e9928540310cf060b44c3dbf9457d44a7721fdc0d67724ff81cb450dd39b10cfb65db15dda4b8bf09d26bd3801",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 75,
+          "comment" : "",
+          "flags" : [
+            "Valid"
+          ],
+          "msg" : "313233343030",
+          "sig" : "9bbb1052dcfa8ad2715c2eb716ae4f1902dea353d42ee09fd4c0b4fcb8b52b5219e2200016e1199d0061891c263e31b0bc3b55673c19610c4e0fa5408004160b",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 76,
+          "comment" : "",
+          "flags" : [
+            "Valid"
+          ],
+          "msg" : "000000000000000000000000",
+          "sig" : "f63b5c0667c7897fc283296416f7f60e84bbde9cbd832e56be463ed9f568069702b17a2f7c341ebf590706a6388ac76ac613c1675ec0f2c7118f2573422a500b",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 77,
+          "comment" : "",
+          "flags" : [
+            "Valid"
+          ],
+          "msg" : "6161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161",
+          "sig" : "1bc44d7001e6b5b9090fef34b2ca480f9786bbefa7d279353e5881e8dfb91b803ccd46500e270ef0109bfd741037558832120bc2a4f20fbe7b5fb3c3aaf23e08",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 78,
+          "comment" : "",
+          "flags" : [
+            "Valid"
+          ],
+          "msg" : "202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f404142434445464748494a4b4c4d4e4f505152535455565758595a5b5c5d5e5f60",
+          "sig" : "ea8e22143b02372e76e99aece3ed36aec529768a27e2bb49bdc135d44378061e1f62d1ac518f33ebf37b2ee8cc6dde68a4bd7d4a2f4d6cb77f015f71ca9fc30d",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 79,
+          "comment" : "",
+          "flags" : [
+            "Valid"
+          ],
+          "msg" : "ffffffffffffffffffffffffffffffff",
+          "sig" : "8acd679e1a914fc45d5fa83d3021f0509c805c8d271df54e52f43cfbd00cb6222bf81d58fe1de2de378df67ee9f453786626961fe50a9b05f12b6f0899ebdd0a",
+          "result" : "valid"
+        }
+      ]
+    },
+    {
+      "type" : "EddsaVerify",
+      "publicKey" : {
+        "type" : "EDDSAPublicKey",
+        "curve" : "edwards25519",
+        "keySize" : 255,
+        "pk" : "d75a980182b10ab7d54bfed3c964073a0ee172f3daa62325af021a68f707511a"
+      },
+      "publicKeyDer" : "302a300506032b6570032100d75a980182b10ab7d54bfed3c964073a0ee172f3daa62325af021a68f707511a",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMCowBQYDK2VwAyEA11qYAYKxCrfVS/7TyWQHOg7hcvPapiMlrwIaaPcHURo=\n-----END PUBLIC KEY-----\n",
+      "publicKeyJwk" : {
+        "kty" : "OKP",
+        "crv" : "Ed25519",
+        "kid" : "none",
+        "x" : "11qYAYKxCrfVS_7TyWQHOg7hcvPapiMlrwIaaPcHURo"
+      },
+      "tests" : [
+        {
+          "tcId" : 80,
+          "comment" : "draft-josefsson-eddsa-ed25519-02: Test 1",
+          "flags" : [
+            "Ktv"
+          ],
+          "msg" : "",
+          "sig" : "e5564300c360ac729086e2cc806e828a84877f1eb8e5d974d873e065224901555fb8821590a33bacc61e39701cf9b46bd25bf5f0595bbe24655141438e7a100b",
+          "result" : "valid"
+        }
+      ]
+    },
+    {
+      "type" : "EddsaVerify",
+      "publicKey" : {
+        "type" : "EDDSAPublicKey",
+        "curve" : "edwards25519",
+        "keySize" : 255,
+        "pk" : "3d4017c3e843895a92b70aa74d1b7ebc9c982ccf2ec4968cc0cd55f12af4660c"
+      },
+      "publicKeyDer" : "302a300506032b65700321003d4017c3e843895a92b70aa74d1b7ebc9c982ccf2ec4968cc0cd55f12af4660c",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMCowBQYDK2VwAyEAPUAXw+hDiVqStwqnTRt+vJyYLM8uxJaMwM1V8Sr0Zgw=\n-----END PUBLIC KEY-----\n",
+      "publicKeyJwk" : {
+        "kty" : "OKP",
+        "crv" : "Ed25519",
+        "kid" : "none",
+        "x" : "PUAXw-hDiVqStwqnTRt-vJyYLM8uxJaMwM1V8Sr0Zgw"
+      },
+      "tests" : [
+        {
+          "tcId" : 81,
+          "comment" : "draft-josefsson-eddsa-ed25519-02: Test 2",
+          "flags" : [
+            "Ktv"
+          ],
+          "msg" : "72",
+          "sig" : "92a009a9f0d4cab8720e820b5f642540a2b27b5416503f8fb3762223ebdb69da085ac1e43e15996e458f3613d0f11d8c387b2eaeb4302aeeb00d291612bb0c00",
+          "result" : "valid"
+        }
+      ]
+    },
+    {
+      "type" : "EddsaVerify",
+      "publicKey" : {
+        "type" : "EDDSAPublicKey",
+        "curve" : "edwards25519",
+        "keySize" : 255,
+        "pk" : "fc51cd8e6218a1a38da47ed00230f0580816ed13ba3303ac5deb911548908025"
+      },
+      "publicKeyDer" : "302a300506032b6570032100fc51cd8e6218a1a38da47ed00230f0580816ed13ba3303ac5deb911548908025",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMCowBQYDK2VwAyEA/FHNjmIYoaONpH7QAjDwWAgW7RO6MwOsXeuRFUiQgCU=\n-----END PUBLIC KEY-----\n",
+      "publicKeyJwk" : {
+        "kty" : "OKP",
+        "crv" : "Ed25519",
+        "kid" : "none",
+        "x" : "_FHNjmIYoaONpH7QAjDwWAgW7RO6MwOsXeuRFUiQgCU"
+      },
+      "tests" : [
+        {
+          "tcId" : 82,
+          "comment" : "draft-josefsson-eddsa-ed25519-02: Test 3",
+          "flags" : [
+            "Ktv"
+          ],
+          "msg" : "af82",
+          "sig" : "6291d657deec24024827e69c3abe01a30ce548a284743a445e3680d7db5ac3ac18ff9b538d16f290ae67f760984dc6594a7c15e9716ed28dc027beceea1ec40a",
+          "result" : "valid"
+        }
+      ]
+    },
+    {
+      "type" : "EddsaVerify",
+      "publicKey" : {
+        "type" : "EDDSAPublicKey",
+        "curve" : "edwards25519",
+        "keySize" : 255,
+        "pk" : "278117fc144c72340f67d0f2316e8386ceffbf2b2428c9c51fef7c597f1d426e"
+      },
+      "publicKeyDer" : "302a300506032b6570032100278117fc144c72340f67d0f2316e8386ceffbf2b2428c9c51fef7c597f1d426e",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMCowBQYDK2VwAyEAJ4EX/BRMcjQPZ9DyMW6Dhs7/vyskKMnFH+98WX8dQm4=\n-----END PUBLIC KEY-----\n",
+      "publicKeyJwk" : {
+        "kty" : "OKP",
+        "crv" : "Ed25519",
+        "kid" : "none",
+        "x" : "J4EX_BRMcjQPZ9DyMW6Dhs7_vyskKMnFH-98WX8dQm4"
+      },
+      "tests" : [
+        {
+          "tcId" : 83,
+          "comment" : "draft-josefsson-eddsa-ed25519-02: Test 1024",
+          "flags" : [
+            "Ktv"
+          ],
+          "msg" : "08b8b2b733424243760fe426a4b54908632110a66c2f6591eabd3345e3e4eb98fa6e264bf09efe12ee50f8f54e9f77b1e355f6c50544e23fb1433ddf73be84d879de7c0046dc4996d9e773f4bc9efe5738829adb26c81b37c93a1b270b20329d658675fc6ea534e0810a4432826bf58c941efb65d57a338bbd2e26640f89ffbc1a858efcb8550ee3a5e1998bd177e93a7363c344fe6b199ee5d02e82d522c4feba15452f80288a821a579116ec6dad2b3b310da903401aa62100ab5d1a36553e06203b33890cc9b832f79ef80560ccb9a39ce767967ed628c6ad573cb116dbefefd75499da96bd68a8a97b928a8bbc103b6621fcde2beca1231d206be6cd9ec7aff6f6c94fcd7204ed3455c68c83f4a41da4af2b74ef5c53f1d8ac70bdcb7ed185ce81bd84359d44254d95629e9855a94a7c1958d1f8ada5d0532ed8a5aa3fb2d17ba70eb6248e594e1a2297acbbb39d502f1a8c6eb6f1ce22b3de1a1f40cc24554119a831a9aad6079cad88425de6bde1a9187ebb6092cf67bf2b13fd65f27088d78b7e883c8759d2c4f5c65adb7553878ad575f9fad878e80a0c9ba63bcbcc2732e69485bbc9c90bfbd62481d9089beccf80cfe2df16a2cf65bd92dd597b0707e0917af48bbb75fed413d238f5555a7a569d80c3414a8d0859dc65a46128bab27af87a71314f318c782b23ebfe808b82b0ce26401d2e22f04d83d1255dc51addd3b75a2b1ae0784504df543af8969be3ea7082ff7fc9888c144da2af58429ec96031dbcad3dad9af0dcbaaaf268cb8fcffead94f3c7ca495e056a9b47acdb751fb73e666c6c655ade8297297d07ad1ba5e43f1bca32301651339e22904cc8c42f58c30c04aafdb038dda0847dd988dcda6f3bfd15c4b4c4525004aa06eeff8ca61783aacec57fb3d1f92b0fe2fd1a85f6724517b65e614ad6808d6f6ee34dff7310fdc82aebfd904b01e1dc54b2927094b2db68d6f903b68401adebf5a7e08d78ff4ef5d63653a65040cf9bfd4aca7984a74d37145986780fc0b16ac451649de6188a7dbdf191f64b5fc5e2ab47b57f7f7276cd419c17a3ca8e1b939ae49e488acba6b965610b5480109c8b17b80e1b7b750dfc7598d5d5011fd2dcc5600a32ef5b52a1ecc820e308aa342721aac0943bf6686b64b2579376504ccc493d97e6aed3fb0f9cd71a43dd497f01f17c0e2cb3797aa2a2f256656168e6c496afc5fb93246f6b1116398a346f1a641f3b041e989f7914f90cc2c7fff357876e506b50d334ba77c225bc307ba537152f3f1610e4eafe595f6d9d90d11faa933a15ef1369546868a7f3a45a96768d40fd9d03412c091c6315cf4fde7cb68606937380db2eaaa707b4c4185c32eddcdd306705e4dc1ffc872eeee475a64dfac86aba41c0618983f8741c5ef68d3a101e8a3b8cac60c905c15fc910840b94c00a0b9d0",
+          "sig" : "0aab4c900501b3e24d7cdf4663326a3a87df5e4843b2cbdb67cbf6e460fec350aa5371b1508f9f4528ecea23c436d94b5e8fcd4f681e30a6ac00a9704a188a03",
+          "result" : "valid"
+        }
+      ]
+    },
+    {
+      "type" : "EddsaVerify",
+      "publicKey" : {
+        "type" : "EDDSAPublicKey",
+        "curve" : "edwards25519",
+        "keySize" : 255,
+        "pk" : "100fdf47fb94f1536a4f7c3fda27383fa03375a8f527c537e6f1703c47f94f86"
+      },
+      "publicKeyDer" : "302a300506032b6570032100100fdf47fb94f1536a4f7c3fda27383fa03375a8f527c537e6f1703c47f94f86",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMCowBQYDK2VwAyEAEA/fR/uU8VNqT3w/2ic4P6Azdaj1J8U35vFwPEf5T4Y=\n-----END PUBLIC KEY-----\n",
+      "publicKeyJwk" : {
+        "kty" : "OKP",
+        "crv" : "Ed25519",
+        "kid" : "none",
+        "x" : "EA_fR_uU8VNqT3w_2ic4P6Azdaj1J8U35vFwPEf5T4Y"
+      },
+      "tests" : [
+        {
+          "tcId" : 84,
+          "comment" : "Signature with S just under the bound. [David Benjamin]",
+          "flags" : [
+            "Ktv"
+          ],
+          "msg" : "124e583f8b8eca58bb29c271b41d36986bbc45541f8e51f9cb0133eca447601e",
+          "sig" : "dac119d6ca87fc59ae611c157048f4d4fc932a149dbe20ec6effd1436abf83ea05c7df0fef06147241259113909bc71bd3c53ba4464ffcad3c0968f2ffffff0f",
+          "result" : "valid"
+        }
+      ]
+    },
+    {
+      "type" : "EddsaVerify",
+      "publicKey" : {
+        "type" : "EDDSAPublicKey",
+        "curve" : "edwards25519",
+        "keySize" : 255,
+        "pk" : "100fdf47fb94f1536a4f7c3fda27383fa03375a8f527c537e6f1703c47f94f86"
+      },
+      "publicKeyDer" : "302a300506032b6570032100100fdf47fb94f1536a4f7c3fda27383fa03375a8f527c537e6f1703c47f94f86",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMCowBQYDK2VwAyEAEA/fR/uU8VNqT3w/2ic4P6Azdaj1J8U35vFwPEf5T4Y=\n-----END PUBLIC KEY-----\n",
+      "publicKeyJwk" : {
+        "kty" : "OKP",
+        "crv" : "Ed25519",
+        "kid" : "none",
+        "x" : "EA_fR_uU8VNqT3w_2ic4P6Azdaj1J8U35vFwPEf5T4Y"
+      },
+      "tests" : [
+        {
+          "tcId" : 85,
+          "comment" : "Signature with S just above the bound. [David Benjamin]",
+          "flags" : [
+            "InvalidKtv"
+          ],
+          "msg" : "6a0bc2b0057cedfc0fa2e3f7f7d39279b30f454a69dfd1117c758d86b19d85e0",
+          "sig" : "0971f86d2c9c78582524a103cb9cf949522ae528f8054dc20107d999be673ff4e25ebf2f2928766b1248bec6e91697775f8446639ede46ad4df4053000000010",
+          "result" : "invalid"
+        }
+      ]
+    },
+    {
+      "type" : "EddsaVerify",
+      "publicKey" : {
+        "type" : "EDDSAPublicKey",
+        "curve" : "edwards25519",
+        "keySize" : 255,
+        "pk" : "8fd659b77b558ed93882c1157438450ac86ec62d421d568e98ee236f3810295a"
+      },
+      "publicKeyDer" : "302a300506032b65700321008fd659b77b558ed93882c1157438450ac86ec62d421d568e98ee236f3810295a",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMCowBQYDK2VwAyEAj9ZZt3tVjtk4gsEVdDhFCshuxi1CHVaOmO4jbzgQKVo=\n-----END PUBLIC KEY-----\n",
+      "publicKeyJwk" : {
+        "kty" : "OKP",
+        "crv" : "Ed25519",
+        "kid" : "none",
+        "x" : "j9ZZt3tVjtk4gsEVdDhFCshuxi1CHVaOmO4jbzgQKVo"
+      },
+      "tests" : [
+        {
+          "tcId" : 86,
+          "comment" : "Random test failure 1",
+          "flags" : [
+            "Ktv"
+          ],
+          "msg" : "b0729a713593a92e46b56eaa66b9e435f7a09a8e7de03b078f6f282285276635f301e7aaafe42187c45d6f5b13f9f16b11195cc125c05b90d24dfe4c",
+          "sig" : "7db17557ac470c0eda4eedaabce99197ab62565653cf911f632ee8be0e5ffcfc88fb94276b42e0798fd3aa2f0318be7fc6a29fae75f70c3dcdc414a0ad866601",
+          "result" : "valid"
+        }
+      ]
+    },
+    {
+      "type" : "EddsaVerify",
+      "publicKey" : {
+        "type" : "EDDSAPublicKey",
+        "curve" : "edwards25519",
+        "keySize" : 255,
+        "pk" : "2a606bf67ac770c607038b004101b325edb569efd3413d2d1f2c3e6b4e6e3082"
+      },
+      "publicKeyDer" : "302a300506032b65700321002a606bf67ac770c607038b004101b325edb569efd3413d2d1f2c3e6b4e6e3082",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMCowBQYDK2VwAyEAKmBr9nrHcMYHA4sAQQGzJe21ae/TQT0tHyw+a05uMII=\n-----END PUBLIC KEY-----\n",
+      "publicKeyJwk" : {
+        "kty" : "OKP",
+        "crv" : "Ed25519",
+        "kid" : "none",
+        "x" : "KmBr9nrHcMYHA4sAQQGzJe21ae_TQT0tHyw-a05uMII"
+      },
+      "tests" : [
+        {
+          "tcId" : 87,
+          "comment" : "Random test failure 2",
+          "flags" : [
+            "Ktv"
+          ],
+          "msg" : "a8546e50ba31cae3234310d32672447be213fad91a227a19669c53d309b959782b0e6b71f8791fdb470043b58122003157d2d96a43a6cbd7d3a8d86bf4c97391883e268d50af80e1e6e12939c2bd50ca746cdadfad4edf1bda875299740724148efb1ebe73fb60088cda890317658627a5f7ab5a0c075d9d8f3f97b6492b35519e50ff6b38377432a7081f9176bb1c29a862deac1336ca20b097a47829cec10a6a7cec178eda2d12f6dc6c87f910454af0123555ba184e68804d9cced60fd5c8c90943e56599c8f0ba59a38491ba5e5a53460682474c07e40ca142983314fd762856bb1093f359da6eb0a756bd93a3160c10dd8feea6b97e7c6a17cb54bd5d7649c05c66d7bdee056671dfdaf689fa3945bb8e29a429f4bd5d355dce9687b06f01d5e33e3999f0e8",
+          "sig" : "67d84d4c3945aaf06e06d524be63acbfb5dbb1988c4aea96a5ee9f7a9b9eecc29df4f66b8aa1d9e8607a58fb1ef0c2ad69aac005b4f58e34103344a9c8871a09",
+          "result" : "valid"
+        }
+      ]
+    },
+    {
+      "type" : "EddsaVerify",
+      "publicKey" : {
+        "type" : "EDDSAPublicKey",
+        "curve" : "edwards25519",
+        "keySize" : 255,
+        "pk" : "c9c946cbc5544ac74eef491f07c5881c16faf7ec31ce4aa91bb60ae7b4539051"
+      },
+      "publicKeyDer" : "302a300506032b6570032100c9c946cbc5544ac74eef491f07c5881c16faf7ec31ce4aa91bb60ae7b4539051",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMCowBQYDK2VwAyEAyclGy8VUSsdO70kfB8WIHBb69+wxzkqpG7YK57RTkFE=\n-----END PUBLIC KEY-----\n",
+      "publicKeyJwk" : {
+        "kty" : "OKP",
+        "crv" : "Ed25519",
+        "kid" : "none",
+        "x" : "yclGy8VUSsdO70kfB8WIHBb69-wxzkqpG7YK57RTkFE"
+      },
+      "tests" : [
+        {
+          "tcId" : 88,
+          "comment" : "Random test failure 3",
+          "flags" : [
+            "Ktv"
+          ],
+          "msg" : "cd2212eddb0706f62c995cef958634f0cb7793444cbf4d30e81c27c41ebea6cb02607510131f9c015692dfd521b148841e9a2d3564d20ac401f6cb8e40f520fe0cafbeaa88840b83013369d879f013463fe52a13267aa0c8c59c45cde9399cd1e6be8cc64cf48315ac2eb31a1c567a4fb7d601746d1f63b5ac020712adbbe07519bded6f",
+          "sig" : "24087d47f3e20af51b9668ae0a88ce76586802d0ec75d8c0f28fc30962b5e1d1a1d509571a1624ed125a8df92a6e963728d6b5de99200b8e285f70feb6f05207",
+          "result" : "valid"
+        }
+      ]
+    },
+    {
+      "type" : "EddsaVerify",
+      "publicKey" : {
+        "type" : "EDDSAPublicKey",
+        "curve" : "edwards25519",
+        "keySize" : 255,
+        "pk" : "32ad026f693d0d2afe7f4388d91c4c964426fcb9e3665c3ebd8650009b815c8e"
+      },
+      "publicKeyDer" : "302a300506032b657003210032ad026f693d0d2afe7f4388d91c4c964426fcb9e3665c3ebd8650009b815c8e",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMCowBQYDK2VwAyEAMq0Cb2k9DSr+f0OI2RxMlkQm/LnjZlw+vYZQAJuBXI4=\n-----END PUBLIC KEY-----\n",
+      "publicKeyJwk" : {
+        "kty" : "OKP",
+        "crv" : "Ed25519",
+        "kid" : "none",
+        "x" : "Mq0Cb2k9DSr-f0OI2RxMlkQm_LnjZlw-vYZQAJuBXI4"
+      },
+      "tests" : [
+        {
+          "tcId" : 89,
+          "comment" : "Random test failure 4",
+          "flags" : [
+            "Ktv"
+          ],
+          "msg" : "ec5c7cb078",
+          "sig" : "d920d421a5956b69bfe1ba834c025e2babb6c7a6d78c97de1d9bb1116dfdd1185147b2887e34e15578172e150774275ea2aad9e02106f7e8ca1caa669a066f0c",
+          "result" : "valid"
+        }
+      ]
+    },
+    {
+      "type" : "EddsaVerify",
+      "publicKey" : {
+        "type" : "EDDSAPublicKey",
+        "curve" : "edwards25519",
+        "keySize" : 255,
+        "pk" : "32ad026f693d0d2afe7f4388d91c4c964426fcb9e3665c3ebd8650009b815c8e"
+      },
+      "publicKeyDer" : "302a300506032b657003210032ad026f693d0d2afe7f4388d91c4c964426fcb9e3665c3ebd8650009b815c8e",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMCowBQYDK2VwAyEAMq0Cb2k9DSr+f0OI2RxMlkQm/LnjZlw+vYZQAJuBXI4=\n-----END PUBLIC KEY-----\n",
+      "publicKeyJwk" : {
+        "kty" : "OKP",
+        "crv" : "Ed25519",
+        "kid" : "none",
+        "x" : "Mq0Cb2k9DSr-f0OI2RxMlkQm_LnjZlw-vYZQAJuBXI4"
+      },
+      "tests" : [
+        {
+          "tcId" : 90,
+          "comment" : "Random test failure 5",
+          "flags" : [
+            "Ktv"
+          ],
+          "msg" : "4668c6a76f0e482190a7175b9f3806a5fe4314a004fa69f988373f7a",
+          "sig" : "4f62daf7f7c162038552ad7d306e195baa37ecf6ca7604142679d7d1128e1f8af52e4cb3545748c44ef1ff1c64e877e4f4d248259b7f6eb56e3ef72097dc8e0c",
+          "result" : "valid"
+        }
+      ]
+    },
+    {
+      "type" : "EddsaVerify",
+      "publicKey" : {
+        "type" : "EDDSAPublicKey",
+        "curve" : "edwards25519",
+        "keySize" : 255,
+        "pk" : "c29ec1894e06d27b4e40486b4fa5063d66a746c7f9c323b12203c03b72b8b78a"
+      },
+      "publicKeyDer" : "302a300506032b6570032100c29ec1894e06d27b4e40486b4fa5063d66a746c7f9c323b12203c03b72b8b78a",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMCowBQYDK2VwAyEAwp7BiU4G0ntOQEhrT6UGPWanRsf5wyOxIgPAO3K4t4o=\n-----END PUBLIC KEY-----\n",
+      "publicKeyJwk" : {
+        "kty" : "OKP",
+        "crv" : "Ed25519",
+        "kid" : "none",
+        "x" : "wp7BiU4G0ntOQEhrT6UGPWanRsf5wyOxIgPAO3K4t4o"
+      },
+      "tests" : [
+        {
+          "tcId" : 91,
+          "comment" : "Random test failure 6",
+          "flags" : [
+            "Ktv"
+          ],
+          "msg" : "0f325ffd87e58131ffa23c05ea4579513b287fdba87b44",
+          "sig" : "6669acf94667c5b541afe5307bde9476b13ae7e0e6058a772101ac8eb0a94331428eb4db0a2c68a9b6c1763b8624dab259b0876cdcfaeacc17b21a18e3fc010a",
+          "result" : "valid"
+        }
+      ]
+    },
+    {
+      "type" : "EddsaVerify",
+      "publicKey" : {
+        "type" : "EDDSAPublicKey",
+        "curve" : "edwards25519",
+        "keySize" : 255,
+        "pk" : "cfda5b899e35764c5229e59295fe1222b7ddce176643697c29e46ecbba10cf10"
+      },
+      "publicKeyDer" : "302a300506032b6570032100cfda5b899e35764c5229e59295fe1222b7ddce176643697c29e46ecbba10cf10",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMCowBQYDK2VwAyEAz9pbiZ41dkxSKeWSlf4SIrfdzhdmQ2l8KeRuy7oQzxA=\n-----END PUBLIC KEY-----\n",
+      "publicKeyJwk" : {
+        "kty" : "OKP",
+        "crv" : "Ed25519",
+        "kid" : "none",
+        "x" : "z9pbiZ41dkxSKeWSlf4SIrfdzhdmQ2l8KeRuy7oQzxA"
+      },
+      "tests" : [
+        {
+          "tcId" : 92,
+          "comment" : "Random test failure 7",
+          "flags" : [
+            "Ktv"
+          ],
+          "msg" : "ec5c7cb078",
+          "sig" : "30490c28f806298225df62103521dcee047153912c33ab8ab8bbdd1ffabd70fd4fdb360f05be535b067d1cf4e78c2cb432206bf280aab3bd21aaa1cb894c5b06",
+          "result" : "valid"
+        }
+      ]
+    },
+    {
+      "type" : "EddsaVerify",
+      "publicKey" : {
+        "type" : "EDDSAPublicKey",
+        "curve" : "edwards25519",
+        "keySize" : 255,
+        "pk" : "32ad026f693d0d2afe7f4388d91c4c964426fcb9e3665c3ebd8650009b815c8e"
+      },
+      "publicKeyDer" : "302a300506032b657003210032ad026f693d0d2afe7f4388d91c4c964426fcb9e3665c3ebd8650009b815c8e",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMCowBQYDK2VwAyEAMq0Cb2k9DSr+f0OI2RxMlkQm/LnjZlw+vYZQAJuBXI4=\n-----END PUBLIC KEY-----\n",
+      "publicKeyJwk" : {
+        "kty" : "OKP",
+        "crv" : "Ed25519",
+        "kid" : "none",
+        "x" : "Mq0Cb2k9DSr-f0OI2RxMlkQm_LnjZlw-vYZQAJuBXI4"
+      },
+      "tests" : [
+        {
+          "tcId" : 93,
+          "comment" : "Random test failure 8",
+          "flags" : [
+            "Ktv"
+          ],
+          "msg" : "5dc9bb87eb11621a93f92abe53515697d2611b2eef73",
+          "sig" : "deecafb6f2ede73fec91a6f10e45b9c1c61c4b9bfbe6b6147e2de0b1df6938971f7896c3ab83851fb5d9e537037bff0fca0ccb4a3cc38f056f91f7d7a0557e08",
+          "result" : "valid"
+        }
+      ]
+    },
+    {
+      "type" : "EddsaVerify",
+      "publicKey" : {
+        "type" : "EDDSAPublicKey",
+        "curve" : "edwards25519",
+        "keySize" : 255,
+        "pk" : "cfda5b899e35764c5229e59295fe1222b7ddce176643697c29e46ecbba10cf10"
+      },
+      "publicKeyDer" : "302a300506032b6570032100cfda5b899e35764c5229e59295fe1222b7ddce176643697c29e46ecbba10cf10",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMCowBQYDK2VwAyEAz9pbiZ41dkxSKeWSlf4SIrfdzhdmQ2l8KeRuy7oQzxA=\n-----END PUBLIC KEY-----\n",
+      "publicKeyJwk" : {
+        "kty" : "OKP",
+        "crv" : "Ed25519",
+        "kid" : "none",
+        "x" : "z9pbiZ41dkxSKeWSlf4SIrfdzhdmQ2l8KeRuy7oQzxA"
+      },
+      "tests" : [
+        {
+          "tcId" : 94,
+          "comment" : "Random test failure 9",
+          "flags" : [
+            "Ktv"
+          ],
+          "msg" : "67484059b2490b1a0a4f8dee77979e26",
+          "sig" : "4cd4f77ed473a6647387f3163541c67a1708a3c3bd1673247cb87f0cb68b3c56f04bfa72970c8a483efe659c87009ab4020b590b6641316b3deddb5450544e02",
+          "result" : "valid"
+        }
+      ]
+    },
+    {
+      "type" : "EddsaVerify",
+      "publicKey" : {
+        "type" : "EDDSAPublicKey",
+        "curve" : "edwards25519",
+        "keySize" : 255,
+        "pk" : "32ad026f693d0d2afe7f4388d91c4c964426fcb9e3665c3ebd8650009b815c8e"
+      },
+      "publicKeyDer" : "302a300506032b657003210032ad026f693d0d2afe7f4388d91c4c964426fcb9e3665c3ebd8650009b815c8e",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMCowBQYDK2VwAyEAMq0Cb2k9DSr+f0OI2RxMlkQm/LnjZlw+vYZQAJuBXI4=\n-----END PUBLIC KEY-----\n",
+      "publicKeyJwk" : {
+        "kty" : "OKP",
+        "crv" : "Ed25519",
+        "kid" : "none",
+        "x" : "Mq0Cb2k9DSr-f0OI2RxMlkQm_LnjZlw-vYZQAJuBXI4"
+      },
+      "tests" : [
+        {
+          "tcId" : 95,
+          "comment" : "Random test failure 10",
+          "flags" : [
+            "Ktv"
+          ],
+          "msg" : "7dcfe60f881e1285676f35b68a1b2dbcdd7be6f719a288ababc28d36e3a42ac3010a1ca54b32760e74",
+          "sig" : "7f8663cf98cbd39d5ff553f00bcf3d0d520605794f8866ce75714d77cc51e66c91818b657d7b0dae430a68353506edc4a714c345f5ddb5c8b958ba3d035f7a01",
+          "result" : "valid"
+        }
+      ]
+    },
+    {
+      "type" : "EddsaVerify",
+      "publicKey" : {
+        "type" : "EDDSAPublicKey",
+        "curve" : "edwards25519",
+        "keySize" : 255,
+        "pk" : "cfda5b899e35764c5229e59295fe1222b7ddce176643697c29e46ecbba10cf10"
+      },
+      "publicKeyDer" : "302a300506032b6570032100cfda5b899e35764c5229e59295fe1222b7ddce176643697c29e46ecbba10cf10",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMCowBQYDK2VwAyEAz9pbiZ41dkxSKeWSlf4SIrfdzhdmQ2l8KeRuy7oQzxA=\n-----END PUBLIC KEY-----\n",
+      "publicKeyJwk" : {
+        "kty" : "OKP",
+        "crv" : "Ed25519",
+        "kid" : "none",
+        "x" : "z9pbiZ41dkxSKeWSlf4SIrfdzhdmQ2l8KeRuy7oQzxA"
+      },
+      "tests" : [
+        {
+          "tcId" : 96,
+          "comment" : "Random test failure 11",
+          "flags" : [
+            "Ktv"
+          ],
+          "msg" : "a020a4381dc9141f47ee508871ab7a8b5a3648727c4281ae9932376f23a8e1bcda0626b7129197d864178631ec89c4332dbb18",
+          "sig" : "1e41a24fe732bd7cab14c2a2f5134ee8c87fcbd2e987e60957ed9239e5c32404d56977e1b4282871896cb10625a1937468e4dc266e16a9c1b8e9891177eca802",
+          "result" : "valid"
+        }
+      ]
+    },
+    {
+      "type" : "EddsaVerify",
+      "publicKey" : {
+        "type" : "EDDSAPublicKey",
+        "curve" : "edwards25519",
+        "keySize" : 255,
+        "pk" : "32ad026f693d0d2afe7f4388d91c4c964426fcb9e3665c3ebd8650009b815c8e"
+      },
+      "publicKeyDer" : "302a300506032b657003210032ad026f693d0d2afe7f4388d91c4c964426fcb9e3665c3ebd8650009b815c8e",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMCowBQYDK2VwAyEAMq0Cb2k9DSr+f0OI2RxMlkQm/LnjZlw+vYZQAJuBXI4=\n-----END PUBLIC KEY-----\n",
+      "publicKeyJwk" : {
+        "kty" : "OKP",
+        "crv" : "Ed25519",
+        "kid" : "none",
+        "x" : "Mq0Cb2k9DSr-f0OI2RxMlkQm_LnjZlw-vYZQAJuBXI4"
+      },
+      "tests" : [
+        {
+          "tcId" : 97,
+          "comment" : "Random test failure 12",
+          "flags" : [
+            "Ktv"
+          ],
+          "msg" : "58e456064dff471109def4ca27fa8310a1df32739655b624f27e6418d34b7f007173f3faa5",
+          "sig" : "6aab49e5c0bc309b783378ee03ffda282f0185cdf94c847701ff307a6ee8d0865411c44e0a8206f6a5f606107451940c2593af790ce1860f4c14ab25b2deae08",
+          "result" : "valid"
+        }
+      ]
+    },
+    {
+      "type" : "EddsaVerify",
+      "publicKey" : {
+        "type" : "EDDSAPublicKey",
+        "curve" : "edwards25519",
+        "keySize" : 255,
+        "pk" : "529919c9c780985a841c42ba6c180ff2d67a276ccfbe281080e47ab71a758f56"
+      },
+      "publicKeyDer" : "302a300506032b6570032100529919c9c780985a841c42ba6c180ff2d67a276ccfbe281080e47ab71a758f56",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMCowBQYDK2VwAyEAUpkZyceAmFqEHEK6bBgP8tZ6J2zPvigQgOR6txp1j1Y=\n-----END PUBLIC KEY-----\n",
+      "publicKeyJwk" : {
+        "kty" : "OKP",
+        "crv" : "Ed25519",
+        "kid" : "none",
+        "x" : "UpkZyceAmFqEHEK6bBgP8tZ6J2zPvigQgOR6txp1j1Y"
+      },
+      "tests" : [
+        {
+          "tcId" : 98,
+          "comment" : "Random test failure 13",
+          "flags" : [
+            "Ktv"
+          ],
+          "msg" : "e1cbf2d86827825613fb7a85811d",
+          "sig" : "01abfa4d6bbc726b196928ec84fd03f0c953a4fa2b228249562ff1442a4f63a7150b064f3712b51c2af768d2c2711a71aabf8d186833e941a0301b82f0502905",
+          "result" : "valid"
+        }
+      ]
+    },
+    {
+      "type" : "EddsaVerify",
+      "publicKey" : {
+        "type" : "EDDSAPublicKey",
+        "curve" : "edwards25519",
+        "keySize" : 255,
+        "pk" : "cfda5b899e35764c5229e59295fe1222b7ddce176643697c29e46ecbba10cf10"
+      },
+      "publicKeyDer" : "302a300506032b6570032100cfda5b899e35764c5229e59295fe1222b7ddce176643697c29e46ecbba10cf10",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMCowBQYDK2VwAyEAz9pbiZ41dkxSKeWSlf4SIrfdzhdmQ2l8KeRuy7oQzxA=\n-----END PUBLIC KEY-----\n",
+      "publicKeyJwk" : {
+        "kty" : "OKP",
+        "crv" : "Ed25519",
+        "kid" : "none",
+        "x" : "z9pbiZ41dkxSKeWSlf4SIrfdzhdmQ2l8KeRuy7oQzxA"
+      },
+      "tests" : [
+        {
+          "tcId" : 99,
+          "comment" : "Random test failure 14",
+          "flags" : [
+            "Ktv"
+          ],
+          "msg" : "a25176b3afea318b2ec11ddacb10caf7179c0b3f8eabbfa2895581138d3c1e0e",
+          "sig" : "2a833aadecd9f28235cb5896bf3781521dc71f28af2e91dbe1735a61dce3e31ac15ca24b3fc47817a59d386bbbb2ce60a6adc0a2703bb2bdea8f70f91051f706",
+          "result" : "valid"
+        }
+      ]
+    },
+    {
+      "type" : "EddsaVerify",
+      "publicKey" : {
+        "type" : "EDDSAPublicKey",
+        "curve" : "edwards25519",
+        "keySize" : 255,
+        "pk" : "32ad026f693d0d2afe7f4388d91c4c964426fcb9e3665c3ebd8650009b815c8e"
+      },
+      "publicKeyDer" : "302a300506032b657003210032ad026f693d0d2afe7f4388d91c4c964426fcb9e3665c3ebd8650009b815c8e",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMCowBQYDK2VwAyEAMq0Cb2k9DSr+f0OI2RxMlkQm/LnjZlw+vYZQAJuBXI4=\n-----END PUBLIC KEY-----\n",
+      "publicKeyJwk" : {
+        "kty" : "OKP",
+        "crv" : "Ed25519",
+        "kid" : "none",
+        "x" : "Mq0Cb2k9DSr-f0OI2RxMlkQm_LnjZlw-vYZQAJuBXI4"
+      },
+      "tests" : [
+        {
+          "tcId" : 100,
+          "comment" : "Random test failure 15",
+          "flags" : [
+            "Ktv"
+          ],
+          "msg" : "a1",
+          "sig" : "1a74ed2cbdc7d8f3827014e8e6ecf8fd2698ac8f86833acccdd400df710fe0d6b0543c9cfa00d52bf024ab7ce0d91981944097233ec134d5c7abbd44bfd32d0d",
+          "result" : "valid"
+        }
+      ]
+    },
+    {
+      "type" : "EddsaVerify",
+      "publicKey" : {
+        "type" : "EDDSAPublicKey",
+        "curve" : "edwards25519",
+        "keySize" : 255,
+        "pk" : "2252b3d57c74cbf8bc460dc2e082847926bc022f09ab6ae95756362bfd1167c1"
+      },
+      "publicKeyDer" : "302a300506032b65700321002252b3d57c74cbf8bc460dc2e082847926bc022f09ab6ae95756362bfd1167c1",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMCowBQYDK2VwAyEAIlKz1Xx0y/i8Rg3C4IKEeSa8Ai8Jq2rpV1Y2K/0RZ8E=\n-----END PUBLIC KEY-----\n",
+      "publicKeyJwk" : {
+        "kty" : "OKP",
+        "crv" : "Ed25519",
+        "kid" : "none",
+        "x" : "IlKz1Xx0y_i8Rg3C4IKEeSa8Ai8Jq2rpV1Y2K_0RZ8E"
+      },
+      "tests" : [
+        {
+          "tcId" : 101,
+          "comment" : "Random test failure 16",
+          "flags" : [
+            "Ktv"
+          ],
+          "msg" : "975ef941710071a9e1e6325a0c860becd7c695b5117c3107b686e330e5",
+          "sig" : "af0fd9dda7e03e12313410d8d8844ebb6fe6b7f65141f22d7bcba5695a25414a9e54326fb44d59fb14707899a8aae70857b23d4080d7ab2c396ef3a36d45ce02",
+          "result" : "valid"
+        }
+      ]
+    },
+    {
+      "type" : "EddsaVerify",
+      "publicKey" : {
+        "type" : "EDDSAPublicKey",
+        "curve" : "edwards25519",
+        "keySize" : 255,
+        "pk" : "c0a773110f975de3732355bb7ec7f0c41c091c0252966070205516693b992a4a"
+      },
+      "publicKeyDer" : "302a300506032b6570032100c0a773110f975de3732355bb7ec7f0c41c091c0252966070205516693b992a4a",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMCowBQYDK2VwAyEAwKdzEQ+XXeNzI1W7fsfwxBwJHAJSlmBwIFUWaTuZKko=\n-----END PUBLIC KEY-----\n",
+      "publicKeyJwk" : {
+        "kty" : "OKP",
+        "crv" : "Ed25519",
+        "kid" : "none",
+        "x" : "wKdzEQ-XXeNzI1W7fsfwxBwJHAJSlmBwIFUWaTuZKko"
+      },
+      "tests" : [
+        {
+          "tcId" : 102,
+          "comment" : "Random test failure 17",
+          "flags" : [
+            "Ktv"
+          ],
+          "msg" : "",
+          "sig" : "0280427e713378f49d478df6373c6cac847b622b567daa2376c839e7ac10e22c380ab0fa8617c9dcfe76c4d9db5459b21dc1413726e46cc8f387d359e344f407",
+          "result" : "valid"
+        }
+      ]
+    },
+    {
+      "type" : "EddsaVerify",
+      "publicKey" : {
+        "type" : "EDDSAPublicKey",
+        "curve" : "edwards25519",
+        "keySize" : 255,
+        "pk" : "cfda5b899e35764c5229e59295fe1222b7ddce176643697c29e46ecbba10cf10"
+      },
+      "publicKeyDer" : "302a300506032b6570032100cfda5b899e35764c5229e59295fe1222b7ddce176643697c29e46ecbba10cf10",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMCowBQYDK2VwAyEAz9pbiZ41dkxSKeWSlf4SIrfdzhdmQ2l8KeRuy7oQzxA=\n-----END PUBLIC KEY-----\n",
+      "publicKeyJwk" : {
+        "kty" : "OKP",
+        "crv" : "Ed25519",
+        "kid" : "none",
+        "x" : "z9pbiZ41dkxSKeWSlf4SIrfdzhdmQ2l8KeRuy7oQzxA"
+      },
+      "tests" : [
+        {
+          "tcId" : 103,
+          "comment" : "Random test failure 18",
+          "flags" : [
+            "Ktv"
+          ],
+          "msg" : "a9e6d94870a67a9fe1cf13b1e6f9150cdd407bf6480ec841ea586ae3935e9787163cf419c1",
+          "sig" : "c97e3190f83bae7729ba473ad46b420b8aad735f0808ea42c0f898ccfe6addd4fd9d9fa3355d5e67ee21ab7e1f805cd07f1fce980e307f4d7ad36cc924eef00c",
+          "result" : "valid"
+        }
+      ]
+    },
+    {
+      "type" : "EddsaVerify",
+      "publicKey" : {
+        "type" : "EDDSAPublicKey",
+        "curve" : "edwards25519",
+        "keySize" : 255,
+        "pk" : "32ad026f693d0d2afe7f4388d91c4c964426fcb9e3665c3ebd8650009b815c8e"
+      },
+      "publicKeyDer" : "302a300506032b657003210032ad026f693d0d2afe7f4388d91c4c964426fcb9e3665c3ebd8650009b815c8e",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMCowBQYDK2VwAyEAMq0Cb2k9DSr+f0OI2RxMlkQm/LnjZlw+vYZQAJuBXI4=\n-----END PUBLIC KEY-----\n",
+      "publicKeyJwk" : {
+        "kty" : "OKP",
+        "crv" : "Ed25519",
+        "kid" : "none",
+        "x" : "Mq0Cb2k9DSr-f0OI2RxMlkQm_LnjZlw-vYZQAJuBXI4"
+      },
+      "tests" : [
+        {
+          "tcId" : 104,
+          "comment" : "Random test failure 19",
+          "flags" : [
+            "Ktv"
+          ],
+          "msg" : "11cb1eafa4c42a8402c4193c4696f7b2e6d4585e4b42dcf1a8b67a80b2da80bc9d4b649fb2f35eaf1f56c426fd0b",
+          "sig" : "14ceb2eaf4688d995d482f44852d71ad878cd7c77b41e60b0065fd01a59b054ee74759224187dbde9e59a763a70277c960892ef89fba997aba2576b2c54ba608",
+          "result" : "valid"
+        }
+      ]
+    },
+    {
+      "type" : "EddsaVerify",
+      "publicKey" : {
+        "type" : "EDDSAPublicKey",
+        "curve" : "edwards25519",
+        "keySize" : 255,
+        "pk" : "c9c946cbc5544ac74eef491f07c5881c16faf7ec31ce4aa91bb60ae7b4539051"
+      },
+      "publicKeyDer" : "302a300506032b6570032100c9c946cbc5544ac74eef491f07c5881c16faf7ec31ce4aa91bb60ae7b4539051",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMCowBQYDK2VwAyEAyclGy8VUSsdO70kfB8WIHBb69+wxzkqpG7YK57RTkFE=\n-----END PUBLIC KEY-----\n",
+      "publicKeyJwk" : {
+        "kty" : "OKP",
+        "crv" : "Ed25519",
+        "kid" : "none",
+        "x" : "yclGy8VUSsdO70kfB8WIHBb69-wxzkqpG7YK57RTkFE"
+      },
+      "tests" : [
+        {
+          "tcId" : 105,
+          "comment" : "Random test failure 20",
+          "flags" : [
+            "Ktv"
+          ],
+          "msg" : "27d465bc632743522aefa23c",
+          "sig" : "c2656951e2a0285585a51ff0eda7e9a23c2dfd2ffa273aee7808f4604e8f9a8c8ea49e9fce4eb2d8d75d36b7238fe6fc13b6c5d9427dd58f8c6615d033c0bd0f",
+          "result" : "valid"
+        }
+      ]
+    },
+    {
+      "type" : "EddsaVerify",
+      "publicKey" : {
+        "type" : "EDDSAPublicKey",
+        "curve" : "edwards25519",
+        "keySize" : 255,
+        "pk" : "c29ec1894e06d27b4e40486b4fa5063d66a746c7f9c323b12203c03b72b8b78a"
+      },
+      "publicKeyDer" : "302a300506032b6570032100c29ec1894e06d27b4e40486b4fa5063d66a746c7f9c323b12203c03b72b8b78a",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMCowBQYDK2VwAyEAwp7BiU4G0ntOQEhrT6UGPWanRsf5wyOxIgPAO3K4t4o=\n-----END PUBLIC KEY-----\n",
+      "publicKeyJwk" : {
+        "kty" : "OKP",
+        "crv" : "Ed25519",
+        "kid" : "none",
+        "x" : "wp7BiU4G0ntOQEhrT6UGPWanRsf5wyOxIgPAO3K4t4o"
+      },
+      "tests" : [
+        {
+          "tcId" : 106,
+          "comment" : "Random test failure 21",
+          "flags" : [
+            "Ktv"
+          ],
+          "msg" : "5ffa",
+          "sig" : "931e5152fcef078c22cc5d6a3a65f06e396289f6f5f2d1efa6340254a53526ef5dc6874eeddf35c3f50991c53cd02bf06313e37d93ee1f7022128ffa3b8f300b",
+          "result" : "valid"
+        }
+      ]
+    },
+    {
+      "type" : "EddsaVerify",
+      "publicKey" : {
+        "type" : "EDDSAPublicKey",
+        "curve" : "edwards25519",
+        "keySize" : 255,
+        "pk" : "529919c9c780985a841c42ba6c180ff2d67a276ccfbe281080e47ab71a758f56"
+      },
+      "publicKeyDer" : "302a300506032b6570032100529919c9c780985a841c42ba6c180ff2d67a276ccfbe281080e47ab71a758f56",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMCowBQYDK2VwAyEAUpkZyceAmFqEHEK6bBgP8tZ6J2zPvigQgOR6txp1j1Y=\n-----END PUBLIC KEY-----\n",
+      "publicKeyJwk" : {
+        "kty" : "OKP",
+        "crv" : "Ed25519",
+        "kid" : "none",
+        "x" : "UpkZyceAmFqEHEK6bBgP8tZ6J2zPvigQgOR6txp1j1Y"
+      },
+      "tests" : [
+        {
+          "tcId" : 107,
+          "comment" : "Random test failure 22",
+          "flags" : [
+            "Ktv"
+          ],
+          "msg" : "25",
+          "sig" : "e4ae21f7a8f4b3b325c161a8c6e53e2edd7005b9c2f8a2e3b0ac4ba94aa80be6f2ee22ac8d4a96b9a3eb73a825e7bb5aff4a3393bf5b4a38119e9c9b1b041106",
+          "result" : "valid"
+        }
+      ]
+    },
+    {
+      "type" : "EddsaVerify",
+      "publicKey" : {
+        "type" : "EDDSAPublicKey",
+        "curve" : "edwards25519",
+        "keySize" : 255,
+        "pk" : "2252b3d57c74cbf8bc460dc2e082847926bc022f09ab6ae95756362bfd1167c1"
+      },
+      "publicKeyDer" : "302a300506032b65700321002252b3d57c74cbf8bc460dc2e082847926bc022f09ab6ae95756362bfd1167c1",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMCowBQYDK2VwAyEAIlKz1Xx0y/i8Rg3C4IKEeSa8Ai8Jq2rpV1Y2K/0RZ8E=\n-----END PUBLIC KEY-----\n",
+      "publicKeyJwk" : {
+        "kty" : "OKP",
+        "crv" : "Ed25519",
+        "kid" : "none",
+        "x" : "IlKz1Xx0y_i8Rg3C4IKEeSa8Ai8Jq2rpV1Y2K_0RZ8E"
+      },
+      "tests" : [
+        {
+          "tcId" : 108,
+          "comment" : "Random test failure 23",
+          "flags" : [
+            "Ktv"
+          ],
+          "msg" : "80fdd6218f29c8c8f6bd820945f9b0854e3a8824",
+          "sig" : "e097e0bd0370bff5bde359175a11b728ee9639095d5df8eda496395565616edfe079977f7d4dc8c75d6113a83d6a55e6e1676408c0967a2906339b43337dcb01",
+          "result" : "valid"
+        }
+      ]
+    },
+    {
+      "type" : "EddsaVerify",
+      "publicKey" : {
+        "type" : "EDDSAPublicKey",
+        "curve" : "edwards25519",
+        "keySize" : 255,
+        "pk" : "2a606bf67ac770c607038b004101b325edb569efd3413d2d1f2c3e6b4e6e3082"
+      },
+      "publicKeyDer" : "302a300506032b65700321002a606bf67ac770c607038b004101b325edb569efd3413d2d1f2c3e6b4e6e3082",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMCowBQYDK2VwAyEAKmBr9nrHcMYHA4sAQQGzJe21ae/TQT0tHyw+a05uMII=\n-----END PUBLIC KEY-----\n",
+      "publicKeyJwk" : {
+        "kty" : "OKP",
+        "crv" : "Ed25519",
+        "kid" : "none",
+        "x" : "KmBr9nrHcMYHA4sAQQGzJe21ae_TQT0tHyw-a05uMII"
+      },
+      "tests" : [
+        {
+          "tcId" : 109,
+          "comment" : "Random test failure 24",
+          "flags" : [
+            "Ktv"
+          ],
+          "msg" : "b477b0480bb84642608b908d29a51cf2fce63f24ee95",
+          "sig" : "28fafbb62b4d688fa79e1ac92851f46e319b161f801d4dc09acc21fdd6780a2c4292b8c1003c61c2bcebe7f3f88ccc4bb26d407387c5f27cb8c94cf6ce810405",
+          "result" : "valid"
+        }
+      ]
+    },
+    {
+      "type" : "EddsaVerify",
+      "publicKey" : {
+        "type" : "EDDSAPublicKey",
+        "curve" : "edwards25519",
+        "keySize" : 255,
+        "pk" : "32ad026f693d0d2afe7f4388d91c4c964426fcb9e3665c3ebd8650009b815c8e"
+      },
+      "publicKeyDer" : "302a300506032b657003210032ad026f693d0d2afe7f4388d91c4c964426fcb9e3665c3ebd8650009b815c8e",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMCowBQYDK2VwAyEAMq0Cb2k9DSr+f0OI2RxMlkQm/LnjZlw+vYZQAJuBXI4=\n-----END PUBLIC KEY-----\n",
+      "publicKeyJwk" : {
+        "kty" : "OKP",
+        "crv" : "Ed25519",
+        "kid" : "none",
+        "x" : "Mq0Cb2k9DSr-f0OI2RxMlkQm_LnjZlw-vYZQAJuBXI4"
+      },
+      "tests" : [
+        {
+          "tcId" : 110,
+          "comment" : "Random test failure 25",
+          "flags" : [
+            "Ktv"
+          ],
+          "msg" : "aa365b442d12b7f3c925",
+          "sig" : "83c40ce13d483cc58ff65844875862d93df4bd367af77efa469ec06a8ed9e6d7905a04879535708ddf225567a815c9b941d405c98e918fd0c151165cea7fb101",
+          "result" : "valid"
+        }
+      ]
+    },
+    {
+      "type" : "EddsaVerify",
+      "publicKey" : {
+        "type" : "EDDSAPublicKey",
+        "curve" : "edwards25519",
+        "keySize" : 255,
+        "pk" : "54cda623245759ad6d43e620a606908befc633d60792bc7798447a0ef38e7311"
+      },
+      "publicKeyDer" : "302a300506032b657003210054cda623245759ad6d43e620a606908befc633d60792bc7798447a0ef38e7311",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMCowBQYDK2VwAyEAVM2mIyRXWa1tQ+YgpgaQi+/GM9YHkrx3mER6DvOOcxE=\n-----END PUBLIC KEY-----\n",
+      "publicKeyJwk" : {
+        "kty" : "OKP",
+        "crv" : "Ed25519",
+        "kid" : "none",
+        "x" : "VM2mIyRXWa1tQ-YgpgaQi-_GM9YHkrx3mER6DvOOcxE"
+      },
+      "tests" : [
+        {
+          "tcId" : 111,
+          "comment" : "Random test failure 26",
+          "flags" : [
+            "Ktv"
+          ],
+          "msg" : "27e792b28b2f1702",
+          "sig" : "14d9b497c19b91d43481c55bb6f5056de252d9ecb637575c807e58e9b4c5eac8b284089d97e2192dc242014363208e2c9a3435edf8928fb1d893553e9be4c703",
+          "result" : "valid"
+        }
+      ]
+    },
+    {
+      "type" : "EddsaVerify",
+      "publicKey" : {
+        "type" : "EDDSAPublicKey",
+        "curve" : "edwards25519",
+        "keySize" : 255,
+        "pk" : "2362bac514d5fad33802642e979a1e82de6eb6f1bcbf6a5b304f2bb02b9e57fe"
+      },
+      "publicKeyDer" : "302a300506032b65700321002362bac514d5fad33802642e979a1e82de6eb6f1bcbf6a5b304f2bb02b9e57fe",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMCowBQYDK2VwAyEAI2K6xRTV+tM4AmQul5oegt5utvG8v2pbME8rsCueV/4=\n-----END PUBLIC KEY-----\n",
+      "publicKeyJwk" : {
+        "kty" : "OKP",
+        "crv" : "Ed25519",
+        "kid" : "none",
+        "x" : "I2K6xRTV-tM4AmQul5oegt5utvG8v2pbME8rsCueV_4"
+      },
+      "tests" : [
+        {
+          "tcId" : 112,
+          "comment" : "Random test failure 27",
+          "flags" : [
+            "Ktv"
+          ],
+          "msg" : "eef3bb0f617c17d0420c115c21c28e3762edc7b7fb048529b84a9c2bc6",
+          "sig" : "242ddb3a5d938d07af690b1b0ef0fa75842c5f9549bf39c8750f75614c712e7cbaf2e37cc0799db38b858d41aec5b9dd2fca6a3c8e082c10408e2cf3932b9d08",
+          "result" : "valid"
+        }
+      ]
+    },
+    {
+      "type" : "EddsaVerify",
+      "publicKey" : {
+        "type" : "EDDSAPublicKey",
+        "curve" : "edwards25519",
+        "keySize" : 255,
+        "pk" : "32ad026f693d0d2afe7f4388d91c4c964426fcb9e3665c3ebd8650009b815c8e"
+      },
+      "publicKeyDer" : "302a300506032b657003210032ad026f693d0d2afe7f4388d91c4c964426fcb9e3665c3ebd8650009b815c8e",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMCowBQYDK2VwAyEAMq0Cb2k9DSr+f0OI2RxMlkQm/LnjZlw+vYZQAJuBXI4=\n-----END PUBLIC KEY-----\n",
+      "publicKeyJwk" : {
+        "kty" : "OKP",
+        "crv" : "Ed25519",
+        "kid" : "none",
+        "x" : "Mq0Cb2k9DSr-f0OI2RxMlkQm_LnjZlw-vYZQAJuBXI4"
+      },
+      "tests" : [
+        {
+          "tcId" : 113,
+          "comment" : "Random test failure 28",
+          "flags" : [
+            "Ktv"
+          ],
+          "msg" : "475f",
+          "sig" : "71a4a06a34075f2fd47bc3abf4714d46db7e97b08cb6180d3f1539ac50b18ce51f8af8ae95ed21d4fa0daab7235925631ecea1fd9d0d8a2ba7a7583fd04b900c",
+          "result" : "valid"
+        }
+      ]
+    },
+    {
+      "type" : "EddsaVerify",
+      "publicKey" : {
+        "type" : "EDDSAPublicKey",
+        "curve" : "edwards25519",
+        "keySize" : 255,
+        "pk" : "037b55b427dc8daa0f80fcebaf0846902309f8a6cf18b465c0ce9b6539629ac8"
+      },
+      "publicKeyDer" : "302a300506032b6570032100037b55b427dc8daa0f80fcebaf0846902309f8a6cf18b465c0ce9b6539629ac8",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMCowBQYDK2VwAyEAA3tVtCfcjaoPgPzrrwhGkCMJ+KbPGLRlwM6bZTlimsg=\n-----END PUBLIC KEY-----\n",
+      "publicKeyJwk" : {
+        "kty" : "OKP",
+        "crv" : "Ed25519",
+        "kid" : "none",
+        "x" : "A3tVtCfcjaoPgPzrrwhGkCMJ-KbPGLRlwM6bZTlimsg"
+      },
+      "tests" : [
+        {
+          "tcId" : 114,
+          "comment" : "Test case for overflow in signature generation",
+          "flags" : [
+            "Ktv"
+          ],
+          "msg" : "01234567",
+          "sig" : "c964e100033ce8888b23466677da4f4aea29923f642ae508f9d0888d788150636ab9b2c3765e91bbb05153801114d9e52dc700df377212222bb766be4b8c020d",
+          "result" : "valid"
+        }
+      ]
+    },
+    {
+      "type" : "EddsaVerify",
+      "publicKey" : {
+        "type" : "EDDSAPublicKey",
+        "curve" : "edwards25519",
+        "keySize" : 255,
+        "pk" : "9c0007698f177998a7666c7cf7973e2b88e9c4946e33804a7bbe8968d2394b2e"
+      },
+      "publicKeyDer" : "302a300506032b65700321009c0007698f177998a7666c7cf7973e2b88e9c4946e33804a7bbe8968d2394b2e",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMCowBQYDK2VwAyEAnAAHaY8XeZinZmx895c+K4jpxJRuM4BKe76JaNI5Sy4=\n-----END PUBLIC KEY-----\n",
+      "publicKeyJwk" : {
+        "kty" : "OKP",
+        "crv" : "Ed25519",
+        "kid" : "none",
+        "x" : "nAAHaY8XeZinZmx895c-K4jpxJRuM4BKe76JaNI5Sy4"
+      },
+      "tests" : [
+        {
+          "tcId" : 115,
+          "comment" : "Test case for overflow in signature generation",
+          "flags" : [
+            "Ktv"
+          ],
+          "msg" : "9399a6db9433d2a28d2b0c11c8794ab7d108c95b",
+          "sig" : "176065c6d64a136a2227687d77f61f3fca3b16122c966276fd9a8b14a1a2cea4c33b3533d11101717016684e3810efbea63bb23773f7cc480174199abd734f08",
+          "result" : "valid"
+        }
+      ]
+    },
+    {
+      "type" : "EddsaVerify",
+      "publicKey" : {
+        "type" : "EDDSAPublicKey",
+        "curve" : "edwards25519",
+        "keySize" : 255,
+        "pk" : "ed3a6f9721dc9729c1f76635bcf080d7036e1c2f0228654ccbbe1e738c17b963"
+      },
+      "publicKeyDer" : "302a300506032b6570032100ed3a6f9721dc9729c1f76635bcf080d7036e1c2f0228654ccbbe1e738c17b963",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMCowBQYDK2VwAyEA7TpvlyHclynB92Y1vPCA1wNuHC8CKGVMy74ec4wXuWM=\n-----END PUBLIC KEY-----\n",
+      "publicKeyJwk" : {
+        "kty" : "OKP",
+        "crv" : "Ed25519",
+        "kid" : "none",
+        "x" : "7TpvlyHclynB92Y1vPCA1wNuHC8CKGVMy74ec4wXuWM"
+      },
+      "tests" : [
+        {
+          "tcId" : 116,
+          "comment" : "Test case for overflow in signature generation",
+          "flags" : [
+            "Ktv"
+          ],
+          "msg" : "7af783afbbd44c1833ab7237ecaf63b94ffdd003",
+          "sig" : "7ca69331eec8610d38f00e2cdbd46966cb359dcde98a257ac6f362cc00c8f4fe85c02285fe4d66e31a44cadb2bf474e1a7957609eb4fe95a71473fe6699aa70d",
+          "result" : "valid"
+        }
+      ]
+    },
+    {
+      "type" : "EddsaVerify",
+      "publicKey" : {
+        "type" : "EDDSAPublicKey",
+        "curve" : "edwards25519",
+        "keySize" : 255,
+        "pk" : "4abfb535313705a6570018440cdec1a3ae33e51f352112fa6acbd0c6bc3ea859"
+      },
+      "publicKeyDer" : "302a300506032b65700321004abfb535313705a6570018440cdec1a3ae33e51f352112fa6acbd0c6bc3ea859",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMCowBQYDK2VwAyEASr+1NTE3BaZXABhEDN7Bo64z5R81IRL6asvQxrw+qFk=\n-----END PUBLIC KEY-----\n",
+      "publicKeyJwk" : {
+        "kty" : "OKP",
+        "crv" : "Ed25519",
+        "kid" : "none",
+        "x" : "Sr-1NTE3BaZXABhEDN7Bo64z5R81IRL6asvQxrw-qFk"
+      },
+      "tests" : [
+        {
+          "tcId" : 117,
+          "comment" : "Test case for overflow in signature generation",
+          "flags" : [
+            "Ktv"
+          ],
+          "msg" : "321b5f663c19e30ee7bbb85e48ecf44db9d3f512",
+          "sig" : "f296715e855d8aecccba782b670163dedc4458fe4eb509a856bcac450920fd2e95a3a3eb212d2d9ccaf948c39ae46a2548af125f8e2ad9b77bd18f92d59f9200",
+          "result" : "valid"
+        }
+      ]
+    },
+    {
+      "type" : "EddsaVerify",
+      "publicKey" : {
+        "type" : "EDDSAPublicKey",
+        "curve" : "edwards25519",
+        "keySize" : 255,
+        "pk" : "4f2162e6bf03a712db0efa418b7e7006e23871d9d7ec555a313885c4afd96385"
+      },
+      "publicKeyDer" : "302a300506032b65700321004f2162e6bf03a712db0efa418b7e7006e23871d9d7ec555a313885c4afd96385",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMCowBQYDK2VwAyEATyFi5r8DpxLbDvpBi35wBuI4cdnX7FVaMTiFxK/ZY4U=\n-----END PUBLIC KEY-----\n",
+      "publicKeyJwk" : {
+        "kty" : "OKP",
+        "crv" : "Ed25519",
+        "kid" : "none",
+        "x" : "TyFi5r8DpxLbDvpBi35wBuI4cdnX7FVaMTiFxK_ZY4U"
+      },
+      "tests" : [
+        {
+          "tcId" : 118,
+          "comment" : "Test case for overflow in signature generation",
+          "flags" : [
+            "Ktv"
+          ],
+          "msg" : "c48890e92aeeb3af04858a8dc1d34f16a4347b91",
+          "sig" : "367d07253a9d5a77d054b9c1a82d3c0a448a51905343320b3559325ef41839608aa45564978da1b2968c556cfb23b0c98a9be83e594d5e769d69d1156e1b1506",
+          "result" : "valid"
+        }
+      ]
+    },
+    {
+      "type" : "EddsaVerify",
+      "publicKey" : {
+        "type" : "EDDSAPublicKey",
+        "curve" : "edwards25519",
+        "keySize" : 255,
+        "pk" : "4abfb535313705a6570018440cdec1a3ae33e51f352112fa6acbd0c6bc3ea859"
+      },
+      "publicKeyDer" : "302a300506032b65700321004abfb535313705a6570018440cdec1a3ae33e51f352112fa6acbd0c6bc3ea859",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMCowBQYDK2VwAyEASr+1NTE3BaZXABhEDN7Bo64z5R81IRL6asvQxrw+qFk=\n-----END PUBLIC KEY-----\n",
+      "publicKeyJwk" : {
+        "kty" : "OKP",
+        "crv" : "Ed25519",
+        "kid" : "none",
+        "x" : "Sr-1NTE3BaZXABhEDN7Bo64z5R81IRL6asvQxrw-qFk"
+      },
+      "tests" : [
+        {
+          "tcId" : 119,
+          "comment" : "regression test for arithmetic error",
+          "flags" : [
+            "TinkOverflow"
+          ],
+          "msg" : "321b5f663c19e30ee7bbb85e48ecf44db9d3f512",
+          "sig" : "f296715e855d8aecccba782b670163dedc4458fe4eb509a856bcac450920fd2e95a3a3eb212d2d9ccaf948c39ae46a2548af125f8e2ad9b77bd18f92d59f9200",
+          "result" : "valid"
+        }
+      ]
+    },
+    {
+      "type" : "EddsaVerify",
+      "publicKey" : {
+        "type" : "EDDSAPublicKey",
+        "curve" : "edwards25519",
+        "keySize" : 255,
+        "pk" : "4f2162e6bf03a712db0efa418b7e7006e23871d9d7ec555a313885c4afd96385"
+      },
+      "publicKeyDer" : "302a300506032b65700321004f2162e6bf03a712db0efa418b7e7006e23871d9d7ec555a313885c4afd96385",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMCowBQYDK2VwAyEATyFi5r8DpxLbDvpBi35wBuI4cdnX7FVaMTiFxK/ZY4U=\n-----END PUBLIC KEY-----\n",
+      "publicKeyJwk" : {
+        "kty" : "OKP",
+        "crv" : "Ed25519",
+        "kid" : "none",
+        "x" : "TyFi5r8DpxLbDvpBi35wBuI4cdnX7FVaMTiFxK_ZY4U"
+      },
+      "tests" : [
+        {
+          "tcId" : 120,
+          "comment" : "regression test for arithmetic error",
+          "flags" : [
+            "TinkOverflow"
+          ],
+          "msg" : "c48890e92aeeb3af04858a8dc1d34f16a4347b91",
+          "sig" : "367d07253a9d5a77d054b9c1a82d3c0a448a51905343320b3559325ef41839608aa45564978da1b2968c556cfb23b0c98a9be83e594d5e769d69d1156e1b1506",
+          "result" : "valid"
+        }
+      ]
+    },
+    {
+      "type" : "EddsaVerify",
+      "publicKey" : {
+        "type" : "EDDSAPublicKey",
+        "curve" : "edwards25519",
+        "keySize" : 255,
+        "pk" : "0717d75ce27ea181ed5a30e6456c649b5cf453a6b4c12cd3f9fd16b31e0c25cd"
+      },
+      "publicKeyDer" : "302a300506032b65700321000717d75ce27ea181ed5a30e6456c649b5cf453a6b4c12cd3f9fd16b31e0c25cd",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMCowBQYDK2VwAyEABxfXXOJ+oYHtWjDmRWxkm1z0U6a0wSzT+f0Wsx4MJc0=\n-----END PUBLIC KEY-----\n",
+      "publicKeyJwk" : {
+        "kty" : "OKP",
+        "crv" : "Ed25519",
+        "kid" : "none",
+        "x" : "BxfXXOJ-oYHtWjDmRWxkm1z0U6a0wSzT-f0Wsx4MJc0"
+      },
+      "tests" : [
+        {
+          "tcId" : 121,
+          "comment" : "regression test for arithmetic error",
+          "flags" : [
+            "TinkOverflow"
+          ],
+          "msg" : "26d5f0631f49106db58c4cfc903691134811b33c",
+          "sig" : "9588e02bc815649d359ce710cdc69814556dd8c8bab1c468f40a49ebefb7f0de7ed49725edfd1b708fa1bad277c35d6c1b9c5ec25990997645780f9203d7dd08",
+          "result" : "valid"
+        }
+      ]
+    },
+    {
+      "type" : "EddsaVerify",
+      "publicKey" : {
+        "type" : "EDDSAPublicKey",
+        "curve" : "edwards25519",
+        "keySize" : 255,
+        "pk" : "db5b9eab7e84e5a13505865fa711c9c896c898609fc11fc9bc1e55028f9496df"
+      },
+      "publicKeyDer" : "302a300506032b6570032100db5b9eab7e84e5a13505865fa711c9c896c898609fc11fc9bc1e55028f9496df",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMCowBQYDK2VwAyEA21ueq36E5aE1BYZfpxHJyJbImGCfwR/JvB5VAo+Ult8=\n-----END PUBLIC KEY-----\n",
+      "publicKeyJwk" : {
+        "kty" : "OKP",
+        "crv" : "Ed25519",
+        "kid" : "none",
+        "x" : "21ueq36E5aE1BYZfpxHJyJbImGCfwR_JvB5VAo-Ult8"
+      },
+      "tests" : [
+        {
+          "tcId" : 122,
+          "comment" : "regression test for arithmetic error",
+          "flags" : [
+            "TinkOverflow"
+          ],
+          "msg" : "2a71f064af982a3a1103a75cef898732d7881981",
+          "sig" : "2217a0be57dd0d6c0090641496bcb65e37213f02a0df50aff0368ee2808e1376504f37b37494132dfc4d4887f58b9e86eff924040db3925ee4f8e1428c4c500e",
+          "result" : "valid"
+        }
+      ]
+    },
+    {
+      "type" : "EddsaVerify",
+      "publicKey" : {
+        "type" : "EDDSAPublicKey",
+        "curve" : "edwards25519",
+        "keySize" : 255,
+        "pk" : "7bac18f6d2625d3915f233434cda38a577247a7332a5170b37142a34644145e0"
+      },
+      "publicKeyDer" : "302a300506032b65700321007bac18f6d2625d3915f233434cda38a577247a7332a5170b37142a34644145e0",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMCowBQYDK2VwAyEAe6wY9tJiXTkV8jNDTNo4pXckenMypRcLNxQqNGRBReA=\n-----END PUBLIC KEY-----\n",
+      "publicKeyJwk" : {
+        "kty" : "OKP",
+        "crv" : "Ed25519",
+        "kid" : "none",
+        "x" : "e6wY9tJiXTkV8jNDTNo4pXckenMypRcLNxQqNGRBReA"
+      },
+      "tests" : [
+        {
+          "tcId" : 123,
+          "comment" : "regression test for arithmetic error",
+          "flags" : [
+            "TinkOverflow"
+          ],
+          "msg" : "bf26796cef4ddafcf5033c8d105057db0210b6ad",
+          "sig" : "1fda6dd4519fdbefb515bfa39e8e5911f4a0a8aa65f40ef0c542b8b34b87f9c249dc57f320718ff457ed5915c4d0fc352affc1287724d3f3a9de1ff777a02e01",
+          "result" : "valid"
+        }
+      ]
+    },
+    {
+      "type" : "EddsaVerify",
+      "publicKey" : {
+        "type" : "EDDSAPublicKey",
+        "curve" : "edwards25519",
+        "keySize" : 255,
+        "pk" : "7bac18f6d2625d3915f233434cda38a577247a7332a5170b37142a34644145e0"
+      },
+      "publicKeyDer" : "302a300506032b65700321007bac18f6d2625d3915f233434cda38a577247a7332a5170b37142a34644145e0",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMCowBQYDK2VwAyEAe6wY9tJiXTkV8jNDTNo4pXckenMypRcLNxQqNGRBReA=\n-----END PUBLIC KEY-----\n",
+      "publicKeyJwk" : {
+        "kty" : "OKP",
+        "crv" : "Ed25519",
+        "kid" : "none",
+        "x" : "e6wY9tJiXTkV8jNDTNo4pXckenMypRcLNxQqNGRBReA"
+      },
+      "tests" : [
+        {
+          "tcId" : 124,
+          "comment" : "regression test for arithmetic error",
+          "flags" : [
+            "TinkOverflow"
+          ],
+          "msg" : "bf26796cef4ddafcf5033c8d105057db0210b6ad",
+          "sig" : "1fda6dd4519fdbefb515bfa39e8e5911f4a0a8aa65f40ef0c542b8b34b87f9c249dc57f320718ff457ed5915c4d0fc352affc1287724d3f3a9de1ff777a02e01",
+          "result" : "valid"
+        }
+      ]
+    },
+    {
+      "type" : "EddsaVerify",
+      "publicKey" : {
+        "type" : "EDDSAPublicKey",
+        "curve" : "edwards25519",
+        "keySize" : 255,
+        "pk" : "38ead304624abebf3e2b31e20e5629531e3fc659008887c9106f5e55adbbc62a"
+      },
+      "publicKeyDer" : "302a300506032b657003210038ead304624abebf3e2b31e20e5629531e3fc659008887c9106f5e55adbbc62a",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMCowBQYDK2VwAyEAOOrTBGJKvr8+KzHiDlYpUx4/xlkAiIfJEG9eVa27xio=\n-----END PUBLIC KEY-----\n",
+      "publicKeyJwk" : {
+        "kty" : "OKP",
+        "crv" : "Ed25519",
+        "kid" : "none",
+        "x" : "OOrTBGJKvr8-KzHiDlYpUx4_xlkAiIfJEG9eVa27xio"
+      },
+      "tests" : [
+        {
+          "tcId" : 125,
+          "comment" : "regression test for arithmetic error",
+          "flags" : [
+            "TinkOverflow"
+          ],
+          "msg" : "ae03da6997e40cea67935020152d3a9a365cc055",
+          "sig" : "068eafdc2f36b97f9bae7fbda88b530d16b0e35054d3a351e3a4c914b22854c711505e49682e1a447e10a69e3b04d0759c859897b64f71137acf355b63faf100",
+          "result" : "valid"
+        }
+      ]
+    },
+    {
+      "type" : "EddsaVerify",
+      "publicKey" : {
+        "type" : "EDDSAPublicKey",
+        "curve" : "edwards25519",
+        "keySize" : 255,
+        "pk" : "e9bc95049af7e4817b17c402269ba5e767b7348757ac8002fec9e08390c0a9cf"
+      },
+      "publicKeyDer" : "302a300506032b6570032100e9bc95049af7e4817b17c402269ba5e767b7348757ac8002fec9e08390c0a9cf",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMCowBQYDK2VwAyEA6byVBJr35IF7F8QCJpul52e3NIdXrIAC/sngg5DAqc8=\n-----END PUBLIC KEY-----\n",
+      "publicKeyJwk" : {
+        "kty" : "OKP",
+        "crv" : "Ed25519",
+        "kid" : "none",
+        "x" : "6byVBJr35IF7F8QCJpul52e3NIdXrIAC_sngg5DAqc8"
+      },
+      "tests" : [
+        {
+          "tcId" : 126,
+          "comment" : "regression test for arithmetic error",
+          "flags" : [
+            "TinkOverflow"
+          ],
+          "msg" : "489d473f7fb83c7f6823baf65482517bccd8f4ea",
+          "sig" : "43670abc9f09a8a415e76f4a21c6a46156f066b5a37b3c1e867cf67248c7b927e8d13a763e37abf936f5f27f7a8aa290539d21f740efd26b65fd5ad27085f400",
+          "result" : "valid"
+        }
+      ]
+    },
+    {
+      "type" : "EddsaVerify",
+      "publicKey" : {
+        "type" : "EDDSAPublicKey",
+        "curve" : "edwards25519",
+        "keySize" : 255,
+        "pk" : "ee8155ca4e8fe7bc5bca5992044eab7f8c3c6a13db1176f42f46c29da5b064f4"
+      },
+      "publicKeyDer" : "302a300506032b6570032100ee8155ca4e8fe7bc5bca5992044eab7f8c3c6a13db1176f42f46c29da5b064f4",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMCowBQYDK2VwAyEA7oFVyk6P57xbylmSBE6rf4w8ahPbEXb0L0bCnaWwZPQ=\n-----END PUBLIC KEY-----\n",
+      "publicKeyJwk" : {
+        "kty" : "OKP",
+        "crv" : "Ed25519",
+        "kid" : "none",
+        "x" : "7oFVyk6P57xbylmSBE6rf4w8ahPbEXb0L0bCnaWwZPQ"
+      },
+      "tests" : [
+        {
+          "tcId" : 127,
+          "comment" : "regression test for arithmetic error",
+          "flags" : [
+            "TinkOverflow"
+          ],
+          "msg" : "1b704d6692d60a07ad1e1d047b65e105a80d3459",
+          "sig" : "56388f2228893b14ce4f2a5e0cc626591061de3a57c50a5ecab7b9d5bb2caeea191560a1cf2344c75fdb4a085444aa68d727b39f498169eaa82cf64a31f59803",
+          "result" : "valid"
+        }
+      ]
+    },
+    {
+      "type" : "EddsaVerify",
+      "publicKey" : {
+        "type" : "EDDSAPublicKey",
+        "curve" : "edwards25519",
+        "keySize" : 255,
+        "pk" : "db507bfcc9576393f7157bb360532b05c5fcf2e764b690cc6698a4a30d349095"
+      },
+      "publicKeyDer" : "302a300506032b6570032100db507bfcc9576393f7157bb360532b05c5fcf2e764b690cc6698a4a30d349095",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMCowBQYDK2VwAyEA21B7/MlXY5P3FXuzYFMrBcX88udktpDMZpikow00kJU=\n-----END PUBLIC KEY-----\n",
+      "publicKeyJwk" : {
+        "kty" : "OKP",
+        "crv" : "Ed25519",
+        "kid" : "none",
+        "x" : "21B7_MlXY5P3FXuzYFMrBcX88udktpDMZpikow00kJU"
+      },
+      "tests" : [
+        {
+          "tcId" : 128,
+          "comment" : "regression test for arithmetic error",
+          "flags" : [
+            "TinkOverflow"
+          ],
+          "msg" : "dc87030862c4c32f56261e93a367caf458c6be27",
+          "sig" : "553e5845fc480a577da6544e602caadaa00ae3e5aa3dce9ef332b1541b6d5f21bdf1d01e98baf80b8435f9932f89b3eb70f02da24787aac8e77279e797d0bd0b",
+          "result" : "valid"
+        }
+      ]
+    },
+    {
+      "type" : "EddsaVerify",
+      "publicKey" : {
+        "type" : "EDDSAPublicKey",
+        "curve" : "edwards25519",
+        "keySize" : 255,
+        "pk" : "994eaf03309d6ad9d95a656bc1744e2886f029023a3750b34f35086b3c7227f8"
+      },
+      "publicKeyDer" : "302a300506032b6570032100994eaf03309d6ad9d95a656bc1744e2886f029023a3750b34f35086b3c7227f8",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMCowBQYDK2VwAyEAmU6vAzCdatnZWmVrwXROKIbwKQI6N1CzTzUIazxyJ/g=\n-----END PUBLIC KEY-----\n",
+      "publicKeyJwk" : {
+        "kty" : "OKP",
+        "crv" : "Ed25519",
+        "kid" : "none",
+        "x" : "mU6vAzCdatnZWmVrwXROKIbwKQI6N1CzTzUIazxyJ_g"
+      },
+      "tests" : [
+        {
+          "tcId" : 129,
+          "comment" : "regression test for arithmetic error",
+          "flags" : [
+            "TinkOverflow"
+          ],
+          "msg" : "7f41ef68508343ef18813cb2fb332445ec6480cd",
+          "sig" : "bc10f88081b7be1f2505b6e76c5c82e358cf21ec11b7df1f334fb587bada465b53d9f7b4d4fec964432ee91ead1bc32ed3c82f2167da1c834a37515df7fe130e",
+          "result" : "valid"
+        }
+      ]
+    },
+    {
+      "type" : "EddsaVerify",
+      "publicKey" : {
+        "type" : "EDDSAPublicKey",
+        "curve" : "edwards25519",
+        "keySize" : 255,
+        "pk" : "127d37e406e0d83e4b55a09e21e8f50fb88af47e4a43f018cdebffc1948757f0"
+      },
+      "publicKeyDer" : "302a300506032b6570032100127d37e406e0d83e4b55a09e21e8f50fb88af47e4a43f018cdebffc1948757f0",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMCowBQYDK2VwAyEAEn035Abg2D5LVaCeIej1D7iK9H5KQ/AYzev/wZSHV/A=\n-----END PUBLIC KEY-----\n",
+      "publicKeyJwk" : {
+        "kty" : "OKP",
+        "crv" : "Ed25519",
+        "kid" : "none",
+        "x" : "En035Abg2D5LVaCeIej1D7iK9H5KQ_AYzev_wZSHV_A"
+      },
+      "tests" : [
+        {
+          "tcId" : 130,
+          "comment" : "regression test for arithmetic error",
+          "flags" : [
+            "TinkOverflow"
+          ],
+          "msg" : "e1ce107971534bc46a42ac609a1a37b4ca65791d",
+          "sig" : "00c11e76b5866b7c37528b0670188c1a0473fb93c33b72ae604a8865a7d6e094ff722e8ede3cb18389685ff3c4086c29006047466f81e71a329711e0b9294709",
+          "result" : "valid"
+        }
+      ]
+    },
+    {
+      "type" : "EddsaVerify",
+      "publicKey" : {
+        "type" : "EDDSAPublicKey",
+        "curve" : "edwards25519",
+        "keySize" : 255,
+        "pk" : "d83ba84edfb4bec49f29be31d80a64b7c0b5a502438cdb1d0dd1e0e3e55786de"
+      },
+      "publicKeyDer" : "302a300506032b6570032100d83ba84edfb4bec49f29be31d80a64b7c0b5a502438cdb1d0dd1e0e3e55786de",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMCowBQYDK2VwAyEA2DuoTt+0vsSfKb4x2Apkt8C1pQJDjNsdDdHg4+VXht4=\n-----END PUBLIC KEY-----\n",
+      "publicKeyJwk" : {
+        "kty" : "OKP",
+        "crv" : "Ed25519",
+        "kid" : "none",
+        "x" : "2DuoTt-0vsSfKb4x2Apkt8C1pQJDjNsdDdHg4-VXht4"
+      },
+      "tests" : [
+        {
+          "tcId" : 131,
+          "comment" : "regression test for arithmetic error",
+          "flags" : [
+            "TinkOverflow"
+          ],
+          "msg" : "869a827397c585cf35acf88a8728833ab1c8c81e",
+          "sig" : "0a6f0ac47ea136cb3ff00f7a96638e4984048999ee2da0af6e5c86bffb0e70bb97406b6ad5a4b764f7c99ebb6ec0fd434b8efe253b0423ef876c037998e8ab07",
+          "result" : "valid"
+        }
+      ]
+    },
+    {
+      "type" : "EddsaVerify",
+      "publicKey" : {
+        "type" : "EDDSAPublicKey",
+        "curve" : "edwards25519",
+        "keySize" : 255,
+        "pk" : "d3c9aa2f3d6ef217a166e8ae403ed436c37facbbe3beceb78df6eb439f8fa04a"
+      },
+      "publicKeyDer" : "302a300506032b6570032100d3c9aa2f3d6ef217a166e8ae403ed436c37facbbe3beceb78df6eb439f8fa04a",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMCowBQYDK2VwAyEA08mqLz1u8hehZuiuQD7UNsN/rLvjvs63jfbrQ5+PoEo=\n-----END PUBLIC KEY-----\n",
+      "publicKeyJwk" : {
+        "kty" : "OKP",
+        "crv" : "Ed25519",
+        "kid" : "none",
+        "x" : "08mqLz1u8hehZuiuQD7UNsN_rLvjvs63jfbrQ5-PoEo"
+      },
+      "tests" : [
+        {
+          "tcId" : 132,
+          "comment" : "regression test for arithmetic error",
+          "flags" : [
+            "TinkOverflow"
+          ],
+          "msg" : "619d8c4f2c93104be01cd574a385ceca08c33a9e",
+          "sig" : "b7cbb942a6661e2312f79548224f3e44f5841c6e880c68340756a00ce94a914e8404858265985e6bb97ef01d2d7e5e41340309606bfc43c8c6a8f925126b3d09",
+          "result" : "valid"
+        }
+      ]
+    },
+    {
+      "type" : "EddsaVerify",
+      "publicKey" : {
+        "type" : "EDDSAPublicKey",
+        "curve" : "edwards25519",
+        "keySize" : 255,
+        "pk" : "d53280367c1c0b95ac4112218b92c6a71c51fb6312ce668de196c7d52a136155"
+      },
+      "publicKeyDer" : "302a300506032b6570032100d53280367c1c0b95ac4112218b92c6a71c51fb6312ce668de196c7d52a136155",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMCowBQYDK2VwAyEA1TKANnwcC5WsQRIhi5LGpxxR+2MSzmaN4ZbH1SoTYVU=\n-----END PUBLIC KEY-----\n",
+      "publicKeyJwk" : {
+        "kty" : "OKP",
+        "crv" : "Ed25519",
+        "kid" : "none",
+        "x" : "1TKANnwcC5WsQRIhi5LGpxxR-2MSzmaN4ZbH1SoTYVU"
+      },
+      "tests" : [
+        {
+          "tcId" : 133,
+          "comment" : "regression test for arithmetic error",
+          "flags" : [
+            "TinkOverflow"
+          ],
+          "msg" : "5257a0bae8326d259a6ce97420c65e6c2794afe2",
+          "sig" : "27a4f24009e579173ff3064a6eff2a4d20224f8f85fdec982a9cf2e6a3b51537348a1d7851a3a932128a923a393ea84e6b35eb3473c32dceb9d7e9cab03a0f0d",
+          "result" : "valid"
+        }
+      ]
+    },
+    {
+      "type" : "EddsaVerify",
+      "publicKey" : {
+        "type" : "EDDSAPublicKey",
+        "curve" : "edwards25519",
+        "keySize" : 255,
+        "pk" : "94ac2336ba97a476fb4c9f2b5563e4167ca292c6e99e422350a911ae3172c315"
+      },
+      "publicKeyDer" : "302a300506032b657003210094ac2336ba97a476fb4c9f2b5563e4167ca292c6e99e422350a911ae3172c315",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMCowBQYDK2VwAyEAlKwjNrqXpHb7TJ8rVWPkFnyiksbpnkIjUKkRrjFywxU=\n-----END PUBLIC KEY-----\n",
+      "publicKeyJwk" : {
+        "kty" : "OKP",
+        "crv" : "Ed25519",
+        "kid" : "none",
+        "x" : "lKwjNrqXpHb7TJ8rVWPkFnyiksbpnkIjUKkRrjFywxU"
+      },
+      "tests" : [
+        {
+          "tcId" : 134,
+          "comment" : "regression test for arithmetic error",
+          "flags" : [
+            "TinkOverflow"
+          ],
+          "msg" : "5acb6afc9b368f7acac0e71f6a4831c72d628405",
+          "sig" : "985b605fe3f449f68081197a68c714da0bfbf6ac2ab9abb0508b6384ea4999cb8d79af98e86f589409e8d2609a8f8bd7e80aaa8d92a84e7737fbe8dcef41920a",
+          "result" : "valid"
+        }
+      ]
+    },
+    {
+      "type" : "EddsaVerify",
+      "publicKey" : {
+        "type" : "EDDSAPublicKey",
+        "curve" : "edwards25519",
+        "keySize" : 255,
+        "pk" : "e1e7316d231f7f275bdf403360304da1509fdf1af1fd25ca214eaac0a289398f"
+      },
+      "publicKeyDer" : "302a300506032b6570032100e1e7316d231f7f275bdf403360304da1509fdf1af1fd25ca214eaac0a289398f",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMCowBQYDK2VwAyEA4ecxbSMffydb30AzYDBNoVCf3xrx/SXKIU6qwKKJOY8=\n-----END PUBLIC KEY-----\n",
+      "publicKeyJwk" : {
+        "kty" : "OKP",
+        "crv" : "Ed25519",
+        "kid" : "none",
+        "x" : "4ecxbSMffydb30AzYDBNoVCf3xrx_SXKIU6qwKKJOY8"
+      },
+      "tests" : [
+        {
+          "tcId" : 135,
+          "comment" : "regression test for arithmetic error",
+          "flags" : [
+            "TinkOverflow"
+          ],
+          "msg" : "3c87b3453277b353941591fc7eaa7dd37604b42a",
+          "sig" : "1c8fbda3d39e2b441f06da6071c13115cb4115c7c3341704cf6513324d4cf1ef4a1dd7678a048b0dde84e48994d080befcd70854079d44b6a0b0f9fa002d130c",
+          "result" : "valid"
+        }
+      ]
+    },
+    {
+      "type" : "EddsaVerify",
+      "publicKey" : {
+        "type" : "EDDSAPublicKey",
+        "curve" : "edwards25519",
+        "keySize" : 255,
+        "pk" : "fffbeea71215efaf9888fec2cc68edb3703ff11a66fd629b53cbda5eabc18750"
+      },
+      "publicKeyDer" : "302a300506032b6570032100fffbeea71215efaf9888fec2cc68edb3703ff11a66fd629b53cbda5eabc18750",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMCowBQYDK2VwAyEA//vupxIV76+YiP7CzGjts3A/8Rpm/WKbU8vaXqvBh1A=\n-----END PUBLIC KEY-----\n",
+      "publicKeyJwk" : {
+        "kty" : "OKP",
+        "crv" : "Ed25519",
+        "kid" : "none",
+        "x" : "__vupxIV76-YiP7CzGjts3A_8Rpm_WKbU8vaXqvBh1A"
+      },
+      "tests" : [
+        {
+          "tcId" : 136,
+          "comment" : "regression test for arithmetic error",
+          "flags" : [
+            "TinkOverflow"
+          ],
+          "msg" : "0a68e27ef6847bfd9e398b328a0ded3679d4649d",
+          "sig" : "59097233eb141ed948b4f3c28a9496b9a7eca77454ecfe7e46737d1449a0b76b15aacf77cf48af27a668aa4434cfa26c504d75a2bcc4feac46465446234c0508",
+          "result" : "valid"
+        }
+      ]
+    },
+    {
+      "type" : "EddsaVerify",
+      "publicKey" : {
+        "type" : "EDDSAPublicKey",
+        "curve" : "edwards25519",
+        "keySize" : 255,
+        "pk" : "19ccc0527599cb032e0b4c4d74e60f13901768a99df041c3bc1bf6c0ef271169"
+      },
+      "publicKeyDer" : "302a300506032b657003210019ccc0527599cb032e0b4c4d74e60f13901768a99df041c3bc1bf6c0ef271169",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMCowBQYDK2VwAyEAGczAUnWZywMuC0xNdOYPE5AXaKmd8EHDvBv2wO8nEWk=\n-----END PUBLIC KEY-----\n",
+      "publicKeyJwk" : {
+        "kty" : "OKP",
+        "crv" : "Ed25519",
+        "kid" : "none",
+        "x" : "GczAUnWZywMuC0xNdOYPE5AXaKmd8EHDvBv2wO8nEWk"
+      },
+      "tests" : [
+        {
+          "tcId" : 137,
+          "comment" : "regression test for arithmetic error",
+          "flags" : [
+            "TinkOverflow"
+          ],
+          "msg" : "4e9bef60737c7d4dd10bd52567e1473a36d3573d",
+          "sig" : "519105608508fe2f1b6da4cc8b23e39798b1d18d25972beed0404cec722e01ba1b6a0f85e99e092cca8076b101b60d4ac5035684357f4d0daacdc642da742a06",
+          "result" : "valid"
+        }
+      ]
+    },
+    {
+      "type" : "EddsaVerify",
+      "publicKey" : {
+        "type" : "EDDSAPublicKey",
+        "curve" : "edwards25519",
+        "keySize" : 255,
+        "pk" : "0e726e27047563aa0a1a9c2e085d8d26af2acba129d0869c65031e3e6cac329a"
+      },
+      "publicKeyDer" : "302a300506032b65700321000e726e27047563aa0a1a9c2e085d8d26af2acba129d0869c65031e3e6cac329a",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMCowBQYDK2VwAyEADnJuJwR1Y6oKGpwuCF2NJq8qy6Ep0IacZQMePmysMpo=\n-----END PUBLIC KEY-----\n",
+      "publicKeyJwk" : {
+        "kty" : "OKP",
+        "crv" : "Ed25519",
+        "kid" : "none",
+        "x" : "DnJuJwR1Y6oKGpwuCF2NJq8qy6Ep0IacZQMePmysMpo"
+      },
+      "tests" : [
+        {
+          "tcId" : 138,
+          "comment" : "regression test for arithmetic error",
+          "flags" : [
+            "TinkOverflow"
+          ],
+          "msg" : "cc82b3163efda3ba7e9240e765112caa69113694",
+          "sig" : "d8b03ee579e73f16477527fc9dc37a72eaac0748a733772c483ba013944f01ef64fb4ec5e3a95021dc22f4ae282baff6e9b9cc8433c6b6710d82e7397d72ef04",
+          "result" : "valid"
+        }
+      ]
+    },
+    {
+      "type" : "EddsaVerify",
+      "publicKey" : {
+        "type" : "EDDSAPublicKey",
+        "curve" : "edwards25519",
+        "keySize" : 255,
+        "pk" : "e77717b54a2b5e5bce5bccb8f0c5fdb5fd7df77ac254020fc9120dc0d4df4178"
+      },
+      "publicKeyDer" : "302a300506032b6570032100e77717b54a2b5e5bce5bccb8f0c5fdb5fd7df77ac254020fc9120dc0d4df4178",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMCowBQYDK2VwAyEA53cXtUorXlvOW8y48MX9tf1993rCVAIPyRINwNTfQXg=\n-----END PUBLIC KEY-----\n",
+      "publicKeyJwk" : {
+        "kty" : "OKP",
+        "crv" : "Ed25519",
+        "kid" : "none",
+        "x" : "53cXtUorXlvOW8y48MX9tf1993rCVAIPyRINwNTfQXg"
+      },
+      "tests" : [
+        {
+          "tcId" : 139,
+          "comment" : "regression test for arithmetic error",
+          "flags" : [
+            "TinkOverflow"
+          ],
+          "msg" : "923a5c9e7b5635bb6c32c5a408a4a15b652450eb",
+          "sig" : "26da61fdfd38e6d01792813f27840c8b4766b0faaed39d0ee898cb450d94a5d5f57e58b6a003d7f9b56b20561954c6edcf66492d116b8b5e91f205a3a6449d0b",
+          "result" : "valid"
+        }
+      ]
+    },
+    {
+      "type" : "EddsaVerify",
+      "publicKey" : {
+        "type" : "EDDSAPublicKey",
+        "curve" : "edwards25519",
+        "keySize" : 255,
+        "pk" : "6220972d3f7d150b36790d7d522384876d64d640cd9913186815e1629582ed36"
+      },
+      "publicKeyDer" : "302a300506032b65700321006220972d3f7d150b36790d7d522384876d64d640cd9913186815e1629582ed36",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMCowBQYDK2VwAyEAYiCXLT99FQs2eQ19UiOEh21k1kDNmRMYaBXhYpWC7TY=\n-----END PUBLIC KEY-----\n",
+      "publicKeyJwk" : {
+        "kty" : "OKP",
+        "crv" : "Ed25519",
+        "kid" : "none",
+        "x" : "YiCXLT99FQs2eQ19UiOEh21k1kDNmRMYaBXhYpWC7TY"
+      },
+      "tests" : [
+        {
+          "tcId" : 140,
+          "comment" : "regression test for arithmetic error",
+          "flags" : [
+            "TinkOverflow"
+          ],
+          "msg" : "6f2f0245de4587062979d0422d349f93ccdc3af2",
+          "sig" : "4adeaff7a58c5010a5a067feea0ae504d37b0c6a76c6c153e222f13409dff2df0fab69bc5059b97d925dc1b89e9851d7c627cb82d65585f9fd976124553f8902",
+          "result" : "valid"
+        }
+      ]
+    },
+    {
+      "type" : "EddsaVerify",
+      "publicKey" : {
+        "type" : "EDDSAPublicKey",
+        "curve" : "edwards25519",
+        "keySize" : 255,
+        "pk" : "7b64a28c50ec7678a90e3e1a21522e30ac9db7b5215aea2bfb33bea037eab987"
+      },
+      "publicKeyDer" : "302a300506032b65700321007b64a28c50ec7678a90e3e1a21522e30ac9db7b5215aea2bfb33bea037eab987",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMCowBQYDK2VwAyEAe2SijFDsdnipDj4aIVIuMKydt7UhWuor+zO+oDfquYc=\n-----END PUBLIC KEY-----\n",
+      "publicKeyJwk" : {
+        "kty" : "OKP",
+        "crv" : "Ed25519",
+        "kid" : "none",
+        "x" : "e2SijFDsdnipDj4aIVIuMKydt7UhWuor-zO-oDfquYc"
+      },
+      "tests" : [
+        {
+          "tcId" : 141,
+          "comment" : "regression test for arithmetic error",
+          "flags" : [
+            "TinkOverflow"
+          ],
+          "msg" : "6e911edb27a170b983d4dee1110554f804330f41",
+          "sig" : "4204d620cde0c3008c0b2901f5d6b44f88f0e3cb4f4d62252bf6f3cb37c1fb150a9ccb296afe5e7c75f65b5c8edd13dc4910ffe1e1265b3707c59042cf9a5902",
+          "result" : "valid"
+        }
+      ]
+    },
+    {
+      "type" : "EddsaVerify",
+      "publicKey" : {
+        "type" : "EDDSAPublicKey",
+        "curve" : "edwards25519",
+        "keySize" : 255,
+        "pk" : "724452210a9e4c994819229bf12bf84e95768a3a97c08d8d8f5f939a4cad34c5"
+      },
+      "publicKeyDer" : "302a300506032b6570032100724452210a9e4c994819229bf12bf84e95768a3a97c08d8d8f5f939a4cad34c5",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMCowBQYDK2VwAyEAckRSIQqeTJlIGSKb8Sv4TpV2ijqXwI2Nj1+TmkytNMU=\n-----END PUBLIC KEY-----\n",
+      "publicKeyJwk" : {
+        "kty" : "OKP",
+        "crv" : "Ed25519",
+        "kid" : "none",
+        "x" : "ckRSIQqeTJlIGSKb8Sv4TpV2ijqXwI2Nj1-TmkytNMU"
+      },
+      "tests" : [
+        {
+          "tcId" : 142,
+          "comment" : "regression test for arithmetic error",
+          "flags" : [
+            "TinkOverflow"
+          ],
+          "msg" : "b8cf807eea809aaf739aa091f3b7a3f2fd39fb51",
+          "sig" : "f8a69d3fd8c2ff0a9dec41e4c6b43675ce08366a35e220b1185ffc246c339e22c20ac661e866f52054015efd04f42eca2adcee6834c4df923b4a62576e4dff0e",
+          "result" : "valid"
+        }
+      ]
+    },
+    {
+      "type" : "EddsaVerify",
+      "publicKey" : {
+        "type" : "EDDSAPublicKey",
+        "curve" : "edwards25519",
+        "keySize" : 255,
+        "pk" : "bad265b294ed2f422cb6a141694086238fbfe987571aa765d8b4f3a24105aa01"
+      },
+      "publicKeyDer" : "302a300506032b6570032100bad265b294ed2f422cb6a141694086238fbfe987571aa765d8b4f3a24105aa01",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMCowBQYDK2VwAyEAutJlspTtL0IstqFBaUCGI4+/6YdXGqdl2LTzokEFqgE=\n-----END PUBLIC KEY-----\n",
+      "publicKeyJwk" : {
+        "kty" : "OKP",
+        "crv" : "Ed25519",
+        "kid" : "none",
+        "x" : "utJlspTtL0IstqFBaUCGI4-_6YdXGqdl2LTzokEFqgE"
+      },
+      "tests" : [
+        {
+          "tcId" : 143,
+          "comment" : "regression test for arithmetic error",
+          "flags" : [
+            "TinkOverflow"
+          ],
+          "msg" : "01a2b5f7fee813b4e9bd7fc25137648004795010",
+          "sig" : "61792c9442bc6338ac41fd42a40bee9b02ec1836503d60ff725128c63d72808880c36e6190b7da525cbee5d12900aa043547dd14a2709ef9e49d628f37f6b70c",
+          "result" : "valid"
+        }
+      ]
+    },
+    {
+      "type" : "EddsaVerify",
+      "publicKey" : {
+        "type" : "EDDSAPublicKey",
+        "curve" : "edwards25519",
+        "keySize" : 255,
+        "pk" : "0aaee4b723db9b51ba7d22eb23eb8a76a5ac02f4fc9dd06f77bea42e1d37ec5a"
+      },
+      "publicKeyDer" : "302a300506032b65700321000aaee4b723db9b51ba7d22eb23eb8a76a5ac02f4fc9dd06f77bea42e1d37ec5a",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMCowBQYDK2VwAyEACq7ktyPbm1G6fSLrI+uKdqWsAvT8ndBvd76kLh037Fo=\n-----END PUBLIC KEY-----\n",
+      "publicKeyJwk" : {
+        "kty" : "OKP",
+        "crv" : "Ed25519",
+        "kid" : "none",
+        "x" : "Cq7ktyPbm1G6fSLrI-uKdqWsAvT8ndBvd76kLh037Fo"
+      },
+      "tests" : [
+        {
+          "tcId" : 144,
+          "comment" : "regression test for arithmetic error",
+          "flags" : [
+            "TinkOverflow"
+          ],
+          "msg" : "0fbf5d47cb5d498feace8f98f1896208da38a885",
+          "sig" : "fa3cd41e3a8c00b19eecd404a63c3cb787cd30de0dfc936966cff2117f5aff18db6bef80fcfd8856f3fb2e9c3dc47593e9471103032af918feee638a33d40505",
+          "result" : "valid"
+        }
+      ]
+    },
+    {
+      "type" : "EddsaVerify",
+      "publicKey" : {
+        "type" : "EDDSAPublicKey",
+        "curve" : "edwards25519",
+        "keySize" : 255,
+        "pk" : "812344af15a91ba83c2c91e96f1727ac0f3c4c41385b9fa84efa399ada5168be"
+      },
+      "publicKeyDer" : "302a300506032b6570032100812344af15a91ba83c2c91e96f1727ac0f3c4c41385b9fa84efa399ada5168be",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMCowBQYDK2VwAyEAgSNErxWpG6g8LJHpbxcnrA88TEE4W5+oTvo5mtpRaL4=\n-----END PUBLIC KEY-----\n",
+      "publicKeyJwk" : {
+        "kty" : "OKP",
+        "crv" : "Ed25519",
+        "kid" : "none",
+        "x" : "gSNErxWpG6g8LJHpbxcnrA88TEE4W5-oTvo5mtpRaL4"
+      },
+      "tests" : [
+        {
+          "tcId" : 145,
+          "comment" : "regression test for arithmetic error",
+          "flags" : [
+            "TinkOverflow"
+          ],
+          "msg" : "36e67c1939750bffb3e4ba6cb85562612275e862",
+          "sig" : "97fbbcd7a1d0eb42d2f8c42448ef35a2c2472740556b645547865330d6c57068af377fced08aaf810c08cd3c43d296f1975710312e9334c98b485f831efa4103",
+          "result" : "valid"
+        }
+      ]
+    },
+    {
+      "type" : "EddsaVerify",
+      "publicKey" : {
+        "type" : "EDDSAPublicKey",
+        "curve" : "edwards25519",
+        "keySize" : 255,
+        "pk" : "0ee5cb5597fbdf8dccc48b01485e39b33aa133b52d30d23740277267cfec3e3e"
+      },
+      "publicKeyDer" : "302a300506032b65700321000ee5cb5597fbdf8dccc48b01485e39b33aa133b52d30d23740277267cfec3e3e",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMCowBQYDK2VwAyEADuXLVZf7343MxIsBSF45szqhM7UtMNI3QCdyZ8/sPj4=\n-----END PUBLIC KEY-----\n",
+      "publicKeyJwk" : {
+        "kty" : "OKP",
+        "crv" : "Ed25519",
+        "kid" : "none",
+        "x" : "DuXLVZf7343MxIsBSF45szqhM7UtMNI3QCdyZ8_sPj4"
+      },
+      "tests" : [
+        {
+          "tcId" : 146,
+          "comment" : "regression test for arithmetic error",
+          "flags" : [
+            "TinkOverflow"
+          ],
+          "msg" : "13945c894c1d3fe8562e8b20e5f0efaa26ade8e3",
+          "sig" : "d7dbaa337ffd2a5fd8d5fd8ad5aeccc0c0f83795c2c59fe62a40b87903b1ae62ed748a8df5af4d32f9f822a65d0e498b6f40eaf369a9342a1164ee7d08b58103",
+          "result" : "valid"
+        }
+      ]
+    },
+    {
+      "type" : "EddsaVerify",
+      "publicKey" : {
+        "type" : "EDDSAPublicKey",
+        "curve" : "edwards25519",
+        "keySize" : 255,
+        "pk" : "9fba1de92b60b5b4703089763d0d6f9125e4dd7efae41f08a22882aef96892c4"
+      },
+      "publicKeyDer" : "302a300506032b65700321009fba1de92b60b5b4703089763d0d6f9125e4dd7efae41f08a22882aef96892c4",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMCowBQYDK2VwAyEAn7od6StgtbRwMIl2PQ1vkSXk3X765B8IoiiCrvloksQ=\n-----END PUBLIC KEY-----\n",
+      "publicKeyJwk" : {
+        "kty" : "OKP",
+        "crv" : "Ed25519",
+        "kid" : "none",
+        "x" : "n7od6StgtbRwMIl2PQ1vkSXk3X765B8IoiiCrvloksQ"
+      },
+      "tests" : [
+        {
+          "tcId" : 147,
+          "comment" : "regression test for arithmetic error",
+          "flags" : [
+            "TinkOverflow"
+          ],
+          "msg" : "4de142af4b8402f80a47fa812df84f42e283cee7",
+          "sig" : "09a2ed303a2fa7027a1dd7c3b0d25121eeed2b644a2fbc17aa0c8aea4524071ede7e7dd7a536d5497f8165d29e4e1b63200f74bbae39fbbbccb29889c62c1f09",
+          "result" : "valid"
+        }
+      ]
+    },
+    {
+      "type" : "EddsaVerify",
+      "publicKey" : {
+        "type" : "EDDSAPublicKey",
+        "curve" : "edwards25519",
+        "keySize" : 255,
+        "pk" : "7582ab1b52e1316e5c13671f43b39ca36b28133cd0832831bcddd0b0f23398cb"
+      },
+      "publicKeyDer" : "302a300506032b65700321007582ab1b52e1316e5c13671f43b39ca36b28133cd0832831bcddd0b0f23398cb",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMCowBQYDK2VwAyEAdYKrG1LhMW5cE2cfQ7Oco2soEzzQgygxvN3QsPIzmMs=\n-----END PUBLIC KEY-----\n",
+      "publicKeyJwk" : {
+        "kty" : "OKP",
+        "crv" : "Ed25519",
+        "kid" : "none",
+        "x" : "dYKrG1LhMW5cE2cfQ7Oco2soEzzQgygxvN3QsPIzmMs"
+      },
+      "tests" : [
+        {
+          "tcId" : 148,
+          "comment" : "regression test for arithmetic error",
+          "flags" : [
+            "TinkOverflow"
+          ],
+          "msg" : "563357f41b8b23b1d83f19f5667177a67da20b18",
+          "sig" : "e6884a6e6b2e60a0b5862251c001e7c79d581d777d6fc11d218d0aecd79f26a30e2ca22cc7c4674f8b72655bc4ee5cb5494ca07c05177656142ac55cc9d33e02",
+          "result" : "valid"
+        }
+      ]
+    },
+    {
+      "type" : "EddsaVerify",
+      "publicKey" : {
+        "type" : "EDDSAPublicKey",
+        "curve" : "edwards25519",
+        "keySize" : 255,
+        "pk" : "dd2d678bae222f3fb6e8278f08cc9e1a66339c926c29ac0a16f9717f5ee18cd8"
+      },
+      "publicKeyDer" : "302a300506032b6570032100dd2d678bae222f3fb6e8278f08cc9e1a66339c926c29ac0a16f9717f5ee18cd8",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMCowBQYDK2VwAyEA3S1ni64iLz+26CePCMyeGmYznJJsKawKFvlxf17hjNg=\n-----END PUBLIC KEY-----\n",
+      "publicKeyJwk" : {
+        "kty" : "OKP",
+        "crv" : "Ed25519",
+        "kid" : "none",
+        "x" : "3S1ni64iLz-26CePCMyeGmYznJJsKawKFvlxf17hjNg"
+      },
+      "tests" : [
+        {
+          "tcId" : 149,
+          "comment" : "regression test for arithmetic error",
+          "flags" : [
+            "TinkOverflow"
+          ],
+          "msg" : "931bbf9c877a6571cf7d4609fc3eb867edd43f51",
+          "sig" : "6124c206d864507ea5d984b363b4cf583314db6856a45ded5e61eebff4d5e337e0b4c82b445ae2e52d549d2d961eace2ea01f81158e09a9686baa040db65ad08",
+          "result" : "valid"
+        }
+      ]
+    },
+    {
+      "type" : "EddsaVerify",
+      "publicKey" : {
+        "type" : "EDDSAPublicKey",
+        "curve" : "edwards25519",
+        "keySize" : 255,
+        "pk" : "ccbe7cb2e4bc215cee2f885e1d22f7e0d582b2bbbd782c104e548b152d26fc69"
+      },
+      "publicKeyDer" : "302a300506032b6570032100ccbe7cb2e4bc215cee2f885e1d22f7e0d582b2bbbd782c104e548b152d26fc69",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMCowBQYDK2VwAyEAzL58suS8IVzuL4heHSL34NWCsru9eCwQTlSLFS0m/Gk=\n-----END PUBLIC KEY-----\n",
+      "publicKeyJwk" : {
+        "kty" : "OKP",
+        "crv" : "Ed25519",
+        "kid" : "none",
+        "x" : "zL58suS8IVzuL4heHSL34NWCsru9eCwQTlSLFS0m_Gk"
+      },
+      "tests" : [
+        {
+          "tcId" : 150,
+          "comment" : "regression test for arithmetic error",
+          "flags" : [
+            "TinkOverflow"
+          ],
+          "msg" : "44530b0b34f598767a7b875b0caee3c7b9c502d1",
+          "sig" : "cfbd450a2c83cb8436c348822fe3ee347d4ee937b7f2ea11ed755cc52852407c9eec2c1fa30d2f9aef90e89b2cc3bcef2b1b9ca59f712110d19894a9cf6a2802",
+          "result" : "valid"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
This pull request add test vectors to kyber eddsa implementation from the following source: https://github.com/C2SP/wycheproof/blob/0d2dab394df1eb05b0865977f7633d010a98bccd/testvectors_v1/ed25519_test.json