### PR TITLE
Correct BN254 DST

### DIFF
--- a/pairing/bn254/point.go
+++ b/pairing/bn254/point.go
@@ -235,31 +235,31 @@ func mapToPoint(domain []byte, u *gfP) kyber.Point {
 	tv1 := &gfP{}
 	tv1.Set(u)
 	gfpMul(tv1, tv1, tv1)
-	gfpMul(tv1, tv1, c1)
+	gfpMul(tv1, tv1, c1) // tv1 = u^2 * g(Z)
 	tv2 := &gfP{}
-	gfpAdd(tv2, newGFp(1), tv1)
+	gfpAdd(tv2, newGFp(1), tv1) // tv2 = 1 + tv1
 	negTv1 := &gfP{}
 	gfpNeg(negTv1, tv1)
-	gfpAdd(tv1, newGFp(1), negTv1)
+	gfpAdd(tv1, newGFp(1), negTv1) // tv1 = 1 - tv1
 	tv3 := &gfP{}
 	gfpMul(tv3, tv1, tv2)
-	tv3.Invert(tv3)
+	tv3.Invert(tv3) // tv3 = inv0(tv1 * tv2)
 	tv5 := &gfP{}
 	gfpMul(tv5, u, tv1)
 	gfpMul(tv5, tv5, tv3)
-	gfpMul(tv5, tv5, c3)
+	gfpMul(tv5, tv5, c3) // tv5 = u * tv1 * tv3 * tv4
 	x1 := &gfP{}
-	gfpSub(x1, c2, tv5)
+	gfpSub(x1, c2, tv5) // x1 = -Z / 2 - tv5
 	x2 := &gfP{}
-	gfpAdd(x2, c2, tv5)
+	gfpAdd(x2, c2, tv5) // x2 = -Z / 2 + tv5
 	tv7 := &gfP{}
-	gfpMul(tv7, tv2, tv2)
+	gfpMul(tv7, tv2, tv2) // tv7 = tv2^2
 	tv8 := &gfP{}
-	gfpMul(tv8, tv7, tv3)
+	gfpMul(tv8, tv7, tv3) // tv8 = tv2^2 * tv3
 	x3 := &gfP{}
-	gfpMul(x3, tv8, tv8)
-	gfpMul(x3, c4, x3)
-	gfpAdd(x3, newGFp(1), x3)
+	gfpMul(x3, tv8, tv8)      // x3 = tv8^2
+	gfpMul(x3, c4, x3)        // x3 = c4 * x3
+	gfpAdd(x3, newGFp(1), x3) // x3 = 1 + x3
 
 	var x *gfP
 	y := &gfP{}

--- a/pairing/bn254/suite.go
+++ b/pairing/bn254/suite.go
@@ -38,11 +38,11 @@ type Suite struct {
 }
 
 func newDefaultDomainG1() []byte {
-	return []byte("BN254G1_XMD:KECCAK-256_SSWU_RO_")
+	return []byte("BN254G1_XMD:KECCAK-256_SVDW_RO_")
 }
 
 func newDefaultDomainG2() []byte {
-	return []byte("BN254G2_XMD:KECCAK-256_SSWU_RO_")
+	return []byte("BN254G2_XMD:KECCAK-256_SVDW_RO_")
 }
 
 // NewSuite generates and returns a new BN254 pairing suite.


### PR DESCRIPTION
The default domain separator referred to the the wrong implementation, namely, the "[Shallue-van de Woestijne Method](https://datatracker.ietf.org/doc/html/rfc9380#name-shallue-van-de-woestijne-me)" was implemented but the dst referred to: [Simplified Shallue-van de Woestijne-Ulas Method](https://datatracker.ietf.org/doc/html/rfc9380#name-simplified-shallue-van-de-w)

The convention is detailed there: [Suite ID Naming Conventions](https://datatracker.ietf.org/doc/html/rfc9380#name-suite-id-naming-conventions)