### PR TITLE
Use the group-specific scalar type when hashing in BDN

### DIFF
--- a/sign/bdn/mask.go
+++ b/sign/bdn/mask.go
@@ -31,7 +31,7 @@ type Mask struct {
 // The returned Mask will contain pre-computed terms and coefficients for all provided public
 // keys, so it should be re-used for optimal performance (e.g., by creating a "base" mask and
 // cloning it whenever aggregating signatures and/or public keys).
-func NewMask(publics []kyber.Point, myKey kyber.Point) (*Mask, error) {
+func NewMask(group kyber.Group, publics []kyber.Point, myKey kyber.Point) (*Mask, error) {
 	m := &Mask{
 		publics: publics,
 	}
@@ -49,7 +49,7 @@ func NewMask(publics []kyber.Point, myKey kyber.Point) (*Mask, error) {
 	}
 
 	var err error
-	m.publicCoefs, err = hashPointToR(publics)
+	m.publicCoefs, err = hashPointToR(group, publics)
 	if err != nil {
 		return nil, fmt.Errorf("failed to hash public keys: %w", err)
 	}

--- a/sign/bdn/mask_test.go
+++ b/sign/bdn/mask_test.go
@@ -23,7 +23,7 @@ func init() {
 }
 
 func TestMask_CreateMask(t *testing.T) {
-	mask, err := NewMask(publics, nil)
+	mask, err := NewMask(suite, publics, nil)
 	require.NoError(t, err)
 
 	require.Equal(t, len(publics), len(mask.Publics()))
@@ -32,19 +32,19 @@ func TestMask_CreateMask(t *testing.T) {
 	require.Equal(t, n/8+1, mask.Len())
 	require.Equal(t, uint8(0), mask.Mask()[0])
 
-	mask, err = NewMask(publics, publics[2])
+	mask, err = NewMask(suite, publics, publics[2])
 	require.NoError(t, err)
 
 	require.Equal(t, len(publics), len(mask.Publics()))
 	require.Equal(t, 1, mask.CountEnabled())
 	require.Equal(t, uint8(0x4), mask.Mask()[0])
 
-	_, err = NewMask(publics, suite.G1().Point())
+	_, err = NewMask(suite, publics, suite.G1().Point())
 	require.Error(t, err)
 }
 
 func TestMask_SetBit(t *testing.T) {
-	mask, err := NewMask(publics, publics[2])
+	mask, err := NewMask(suite, publics, publics[2])
 	require.NoError(t, err)
 
 	// Make sure the mask is initially as we'd expect.
@@ -111,7 +111,7 @@ func TestMask_SetBit(t *testing.T) {
 }
 
 func TestMask_SetAndMerge(t *testing.T) {
-	mask, err := NewMask(publics, publics[2])
+	mask, err := NewMask(suite, publics, publics[2])
 	require.NoError(t, err)
 
 	err = mask.SetMask([]byte{})
@@ -129,7 +129,7 @@ func TestMask_SetAndMerge(t *testing.T) {
 }
 
 func TestMask_PositionalQueries(t *testing.T) {
-	mask, err := NewMask(publics, publics[2])
+	mask, err := NewMask(suite, publics, publics[2])
 	require.NoError(t, err)
 
 	for i := 0; i < 10000; i++ {


### PR DESCRIPTION
Previously, `hashPointToR` would always use `mod.Int` but that only works with the Kilic backend. This change makes the BDN scheme work with all backends.

This PR is currently based on #546 as it touches masks. You can ignore everything but the last commit.